### PR TITLE
Disallow 0.0.0.0 network with dhcp enabled

### DIFF
--- a/neutron/db/db_base_plugin_v2.py
+++ b/neutron/db/db_base_plugin_v2.py
@@ -459,6 +459,10 @@ class NeutronDbPluginV2(db_base_plugin_common.DbBasePluginCommon,
                 error_message = _("Multicast IP subnet is not supported "
                                   "if enable_dhcp is True.")
                 raise n_exc.InvalidInput(error_message=error_message)
+            elif net.network == netaddr.IPAddress('0.0.0.0'):
+                error_message = _("%s Subnet is not supported "
+                                  "if enable_dhcp is True." % net.network)
+                raise n_exc.InvalidInput(error_message=error_message)
             elif net.is_loopback():
                 error_message = _("Loopback IP subnet is not supported "
                                   "if enable_dhcp is True.")


### PR DESCRIPTION
# Disallow 0.0.0.0 subnet network with dhcp enabled

fixes dhcp-agent errors caused by establishing 0.0.0.1 as default gw

e.g:

### Disallowed example
```
➜  ~ sipcalc 10.0.0.0/4                                                                                                                                                                                                                                                                                                                                                                                                                                                       (staging/monsoon3)
-[ipv4 : 10.0.0.0/4] - 0

[CIDR]
Host address		- 10.0.0.0
Host address (decimal)	- 167772160
Host address (hex)	- A000000
Network address		- 0.0.0.0
Network mask		- 240.0.0.0
Network mask (bits)	- 4
Network mask (hex)	- F0000000
Broadcast address	- 15.255.255.255
Cisco wildcard		- 15.255.255.255
Addresses in network	- 268435456
Network range		- 0.0.0.0 - 15.255.255.255
Usable range		- 0.0.0.1 - 15.255.255.254

(neutron) subnet-create e0c5ee6d-e85a-447d-888a-82097bb9f874 10.0.0.0/4
Invalid input for operation: 0.0.0.0 Subnet is not supported if enable_dhcp is True..
Neutron server returns request_ids: ['req-b9b1d23a-0c43-41c8-a21e-3e95e3412765']
```

### Working example
```
➜  ~ sipcalc 10.0.0.0/5                                                                                                                                                                                                                                                                                                                                                                                                                                                       (staging/monsoon3)
-[ipv4 : 10.0.0.0/5] - 0

[CIDR]
Host address		- 10.0.0.0
Host address (decimal)	- 167772160
Host address (hex)	- A000000
Network address		- 8.0.0.0
Network mask		- 248.0.0.0
Network mask (bits)	- 5
Network mask (hex)	- F8000000
Broadcast address	- 15.255.255.255
Cisco wildcard		- 7.255.255.255
Addresses in network	- 134217728
Network range		- 8.0.0.0 - 15.255.255.255
Usable range		- 8.0.0.1 - 15.255.255.254

(neutron) subnet-create e0c5ee6d-e85a-447d-888a-82097bb9f874 10.0.0.0/5
Created a new subnet:
+-------------------+-----------------------------------------------+
| Field             | Value                                         |
+-------------------+-----------------------------------------------+
| allocation_pools  | {"start": "8.0.0.2", "end": "15.255.255.254"} |
| cidr              | 8.0.0.0/5                                     |
| created_at        | 2018-04-11T13:18:32                           |
| description       |                                               |
| dns_nameservers   |                                               |
| enable_dhcp       | True                                          |
| gateway_ip        | 8.0.0.1                                       |
| host_routes       |                                               |
| id                | 914bb279-4a9a-4937-94c4-45b89bf7aba9          |
| ip_version        | 4                                             |
| ipv6_address_mode |                                               |
| ipv6_ra_mode      |                                               |
| name              |                                               |
| network_id        | e0c5ee6d-e85a-447d-888a-82097bb9f874          |
| subnetpool_id     |                                               |
| tenant_id         | c63b0282cf7a4dbf9c699eda2c437742              |
| updated_at        | 2018-04-11T13:18:32                           |
+-------------------+-----------------------------------------------+
```
