### PR TITLE
Temporary disable SA assertions for port list with limit

### DIFF
--- a/neutron/db/db_base_plugin_v2.py
+++ b/neutron/db/db_base_plugin_v2.py
@@ -1395,12 +1395,14 @@ class NeutronDbPluginV2(db_base_plugin_common.DbBasePluginCommon,
                                                  *args, **kwargs)
         ip_addresses = fixed_ips.get('ip_address')
         subnet_ids = fixed_ips.get('subnet_id')
+        query._enable_assertions = False
         if ip_addresses:
             query = query.filter(
                 Port.fixed_ips.any(IPAllocation.ip_address.in_(ip_addresses)))
         if subnet_ids:
             query = query.filter(
                 Port.fixed_ips.any(IPAllocation.subnet_id.in_(subnet_ids)))
+        query._enable_assertions = True
         return query
 
     @db_api.retry_if_session_inactive()

--- a/neutron/tests/unit/db/test_db_base_plugin_v2.py
+++ b/neutron/tests/unit/db/test_db_base_plugin_v2.py
@@ -1161,6 +1161,21 @@ fixed_ips=ip_address%%3D%s&fixed_ips=ip_address%%3D%s&fixed_ips=subnet_id%%3D%s
             self._test_list_resources('port', [port1],
                                       query_params=query_params)
 
+    def test_list_ports_filtered_by_fixed_ip_with_limit(self):
+        # for this test we need to enable overlapping ips
+        cfg.CONF.set_default('allow_overlapping_ips', True)
+        with self.port() as port1, self.port():
+            fixed_ips = port1['port']['fixed_ips'][0]
+            query_params = ("fixed_ips=ip_address%%3D%s&"
+                           "fixed_ips=ip_address%%3D%s&"
+                           "fixed_ips=subnet_id%%3D%s&"
+                           "limit=500"
+                           "" % (fixed_ips['ip_address'],
+                                 '192.168.126.5',
+                                 fixed_ips['subnet_id']))
+            self._test_list_resources('port', [port1],
+                                      query_params=query_params)
+
     def test_list_ports_public_network(self):
         with self.network(shared=True) as network:
             with self.subnet(network) as subnet:


### PR DESCRIPTION
An API request for a portlisting filtered by ip-address or subnet
failed with a 500, as get_collection_query() in _get_ports_query()
already sets a limit on the query. Subsequent query.filter() calls
fail with an exception. To circumvent this we disable the SA
assertions around this query, including _no_limit_offset() until
a real fix is available. We can do this because the assertion is
in place to prevent someone to apply a filter() on a already limit()ed
query, as the filter will be executed first in any case - but this is
exactly what we want here.

The bug was introduced by Openstack change-id Ia6e916a9dae5f5ef203259c3d1c6e1c30445c07d
and commit 5b7c8c3e27dab38a3b336bb3ac0a87b98944b6cf