### PR TITLE
Limit max ports per rpc for dhcp_ready_ports()

### DIFF
--- a/neutron/conf/agent/dhcp.py
+++ b/neutron/conf/agent/dhcp.py
@@ -58,7 +58,11 @@ DHCP_AGENT_OPTS = [
     cfg.IntOpt('num_sync_threads', default=4,
                help=_('Number of threads to use during sync process. '
                       'Should not exceed connection pool size configured on '
-                      'server.'))
+                      'server.')),
+    cfg.IntOpt('ports_ready_per_iteration', default=64,
+               help=_('Maximum number of ports ready per RPC message. '
+                      'This is the maximum of how many ports are sent to '
+                      'neutron-server in one dhcp_ready_on_ports() call.')),
 ]
 
 DHCP_OPTS = [


### PR DESCRIPTION
If neutron-dhcp-agent sends all ports it has in ready state
to the neutron-server, neutron-server might not be able to
respond in time (that is, before the rpc timeout hits). With
this patch we limit the number of ports sent to neuton-server
in one call to give neutron-server the change to process all
its contents.