### PR TITLE
Add explicit policy-enforcement for port.security_groups

### DIFF
--- a/neutron/extensions/securitygroup.py
+++ b/neutron/extensions/securitygroup.py
@@ -281,6 +281,7 @@ EXTENDED_ATTRIBUTES_2_0 = {
                                'convert_to':
                                    converters.convert_none_to_empty_list,
                                'validate': {'type:uuid_list': None},
+                               'enforce_policy': True,
                                'default': const.ATTR_NOT_SPECIFIED}}}
 
 # Register the configuration options


### PR DESCRIPTION
Our customers want to be able to prohibit certain colleagues from
changing the security_groups. For this, we have to tell neutron to
explicitly enforce policy for `Port.security_groups`.
After that, neutron checks for `update_port:security_groups` and
`create_port:security_groups` in addition to `update_port` and
`create_port`.