### PR TITLE
remove bond interfaces from bridge before adding new ones

### DIFF
--- a/neutron/plugins/ml2/drivers/linuxbridge/agent/linuxbridge_neutron_agent.py
+++ b/neutron/plugins/ml2/drivers/linuxbridge/agent/linuxbridge_neutron_agent.py
@@ -458,6 +458,11 @@ class LinuxBridgeManager(amb.CommonAgentManagerBase):
                 if bridge:
                     bridge.delif(interface)
 
+                # Check if other bond interfaces are part of the bridge and remove them
+                for iface in bridge_device.get_interfaces():
+                    if iface.startswith('bond'):
+                        bridge_device.delif(iface)
+
                 bridge_device.addif(interface)
             except Exception as e:
                 LOG.error("Unable to add %(interface)s to %(bridge_name)s"


### PR DESCRIPTION
ensuring only one bond subinterface is assigned to the bridge at any
time