### PR TITLE
dns: improve PTR record deletion if created as managed.

### DIFF
--- a/neutron/db/dns_db.py
+++ b/neutron/db/dns_db.py
@@ -207,6 +207,9 @@ class DNSDbMixin(object):
 
     def _delete_floatingip_from_external_dns_service(self, context, dns_domain,
                                                      dns_name, records):
+        if not self.dns_driver:
+            return
+
         ips = [str(r) for r in records]
         try:
             self.dns_driver.delete_record_set(context, dns_domain, dns_name,


### PR DESCRIPTION
Partially resolves CCM-15693.
- Using expanded context to delete the PTR record in Designate if the user
has modified the PTR value.
- Should prevent situation when a 'left-over' PTR would cause an error
on FIP allocation with dns-name and dns-domain;
- Add few logs for records deletion in designate.