### PR TITLE
get_detailed_tenant_quotas: Check for existing resource before access…

### DIFF
--- a/neutron/db/quota/driver.py
+++ b/neutron/db/quota/driver.py
@@ -106,7 +106,8 @@ class DbQuotaDriver(object):
         # update with specific tenant limits
         quota_objs = quota_obj.Quota.get_objects(context, project_id=tenant_id)
         for item in quota_objs:
-            tenant_quota_ext[item['resource']]['limit'] = item['limit']
+            if item['resource'] in tenant_quota_ext:
+                tenant_quota_ext[item['resource']]['limit'] = item['limit']
         return tenant_quota_ext
 
     @staticmethod


### PR DESCRIPTION
…ing it from dict

Upgrading Neutron from lbaasv2 to non-lbaasv2 breaks quota detail if theres been already
quotas set for example 'healthmonitor'. This is caused becaused the quota table has
been already populated with (now deprecated) lbaasv2 quota limits which are unconditionally
used to populate the quota detail dictionary result - which is missing this key.

This commit add a check for the existence of the key before accessing the dictionary.