### PR TITLE
Fix check for network address scopes affinity.

### DIFF
--- a/neutron/db/db_base_plugin_v2.py
+++ b/neutron/db/db_base_plugin_v2.py
@@ -13,6 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from collections import defaultdict
 import functools
 
 import netaddr
@@ -1129,7 +1130,7 @@ class NeutronDbPluginV2(db_base_plugin_common.DbBasePluginCommon,
                 ip_version=as_ip_version)
 
         self._check_subnetpool_address_scope_network_affinity(
-            context, subnetpool_id, ip_version)
+            context, subnetpool_id, ip_version, address_scope_id)
 
         subnetpools = subnetpool_obj.SubnetPool.get_objects(
             context, address_scope_id=address_scope_id)
@@ -1144,17 +1145,17 @@ class NeutronDbPluginV2(db_base_plugin_common.DbBasePluginCommon,
 
     def _check_subnetpool_address_scope_network_affinity(self, context,
                                                          subnetpool_id,
-                                                         ip_version):
+                                                         ip_version,
+                                                         address_scope_id):
         """Check whether updating a subnet pool's address scope is allowed.
 
         - Identify the subnets that would be re-scoped
         - Identify the networks that would be affected by re-scoping
         - Find all subnets associated with the affected networks
-        - Perform set difference (all - to_be_rescoped)
-        - If the set difference yields non-zero result size, re-scoping the
-        subnet pool will leave subnets in different address scopes and result
-        in address scope / network affinity violations so raise an exception to
-        block the operation.
+        - Compare address scopes for all of subnet pools related to subnets in
+          each network.
+        If the network has (or will have) different address scopes this check
+        will raise an exception to block the operation.
         """
 
         # TODO(tidwellr) potentially lots of subnets here, optimize this code
@@ -1170,15 +1171,28 @@ class NeutronDbPluginV2(db_base_plugin_common.DbBasePluginCommon,
             context,
             network_id=affected_source_network_ids,
             ip_version=ip_version)
-        all_affected_subnet_ids = set(
-            [subnet.id for subnet in all_network_subnets])
+        affected_networks = defaultdict(list)
+        for subnet in all_network_subnets:
+            # skip subnets without subnet pool
+            if not subnet.subnetpool_id:
+                continue
+            affected_networks[subnet.network_id].append(
+                subnet.subnetpool_id)
 
-        # Use set difference to identify the subnets that would be
-        # violating address scope affinity constraints if the subnet
-        # pool's address scope was changed.
-        violations = all_affected_subnet_ids.difference(rescoped_subnet_ids)
-        if violations:
-            raise addr_scope_exc.NetworkAddressScopeAffinityError()
+        subnet_pools = subnetpool_obj.SubnetPool.get_objects(
+            context,
+            id=[p for n in affected_networks.values() for p in n])
+        affected_scopes = {sp.id:sp.address_scope_id for sp in subnet_pools}
+
+        for pools in affected_networks.values():
+            # as first step will compare with passed address scope
+            last_scope = address_scope_id
+            for pool in pools:
+                # address scopes should be the same in one network
+                scope = affected_scopes.get(pool)
+                if scope and last_scope and scope != last_scope:
+                    raise addr_scope_exc.NetworkAddressScopeAffinityError()
+                last_scope = scope
 
     def _check_subnetpool_update_allowed(self, context, subnetpool_id,
                                          address_scope_id):

--- a/neutron/db/db_base_plugin_v2.py
+++ b/neutron/db/db_base_plugin_v2.py
@@ -1170,12 +1170,8 @@ class NeutronDbPluginV2(db_base_plugin_common.DbBasePluginCommon,
             context,
             network_id=affected_source_network_ids,
             ip_version=ip_version)
-        affected_pool_ids = set()
-        for subnet in all_network_subnets:
-            # skip subnets without subnet pool
-            if not subnet.subnetpool_id:
-                continue
-            affected_pool_ids.add(subnet.subnetpool_id)
+        affected_pool_ids = set(
+            [s.subnetpool_id for s in all_network_subnets if s.subnetpool_id])
 
         subnet_pools = subnetpool_obj.SubnetPool.get_objects(
             context,
@@ -1183,7 +1179,8 @@ class NeutronDbPluginV2(db_base_plugin_common.DbBasePluginCommon,
         affected_scopes = {sp.id: sp.address_scope_id for sp in subnet_pools}
 
         for pool in affected_pool_ids:
-            # address scopes should be the same in one network
+            # address scopes should be the same in all networks raleted to
+            # the address scope.
             scope = affected_scopes.get(pool)
             if scope and scope != address_scope_id:
                 raise addr_scope_exc.NetworkAddressScopeAffinityError()

--- a/neutron/tests/unit/extensions/test_address_scope.py
+++ b/neutron/tests/unit/extensions/test_address_scope.py
@@ -576,7 +576,7 @@ class TestSubnetPoolsWithAddressScopes(AddressScopeTestCase):
                     self.assertEqual(1, subnets_pool_a_count)
                     self.assertEqual(1, subnets_pool_b_count)
 
-    def test_block_update_subnetpool_network_affinity(self):
+    def test_block_update_address_scope_network_affinity(self):
         with self.address_scope(constants.IP_VERSION_4,
                                 name='scope-a') as scope_a,\
             self.address_scope(constants.IP_VERSION_4,
@@ -618,13 +618,22 @@ class TestSubnetPoolsWithAddressScopes(AddressScopeTestCase):
                         ip_version=constants.IP_VERSION_4,
                         tenant_id=scope_a['tenant_id'])
 
+                    api = self._api_for_resource('subnetpools')
+                    # Attempt to update subnetpool_b's prefixes and avoid
+                    # failure.
+                    data = {'subnetpool': {'prefixes': ['10.20.0.0/16',
+                                                        '10.100.0.0/24']}}
+                    req = self.new_update_request('subnetpools', data,
+                                                  subnetpool_b['id'])
+                    res = req.get_response(api)
+                    self.assertEqual(webob.exc.HTTPOk.code,
+                                     res.status_int)
                     # Attempt to update subnetpool_b's address scope and
                     # assert failure.
                     data = {'subnetpool': {'address_scope_id':
                                            scope_b['id']}}
                     req = self.new_update_request('subnetpools', data,
                                                   subnetpool_b['id'])
-                    api = self._api_for_resource('subnetpools')
                     res = req.get_response(api)
                     self.assertEqual(webob.exc.HTTPBadRequest.code,
                                      res.status_int)


### PR DESCRIPTION
This commit fixes incorrect check for network address_scope affinity. Before this changes the function `_check_subnetpool_address_scope_network_affinity` compared lists of subnets related to subnet pools, and it works for upstream because they use 1 to 1 relation for `subnet` -> `subnet_pool` inside one network. But in our infrastructure different subnet pools in one network are valid configurations, so we have to check exactly `address_scope` inside each subnet_pool and they should be the same. This commit adds +1 database query per request for POST/PUT actions for subnet pool API, which in our reality will not add a significant load.