### PR TITLE
dns_integration: fix attribute error for deleted subnet race condition

### DIFF
--- a/neutron/plugins/ml2/extensions/dns_integration.py
+++ b/neutron/plugins/ml2/extensions/dns_integration.py
@@ -444,7 +444,7 @@ def _filter_by_subnet(context, fixed_ips):
         # single get_objects call instead
         subnet = subnet_obj.Subnet.get_object(
             context, id=ip['subnet_id'])
-        if subnet.get('dns_publish_fixed_ip'):
+        if subnet and subnet.get('dns_publish_fixed_ip'):
             filter_fixed_ips = True
             subnet_filtered.append(str(ip['ip_address']))
     if filter_fixed_ips:

--- a/neutron/tests/unit/plugins/ml2/extensions/test_dns_integration.py
+++ b/neutron/tests/unit/plugins/ml2/extensions/test_dns_integration.py
@@ -471,6 +471,15 @@ class DNSIntegrationTestCase(test_plugin.Ml2PluginV2TestCase):
         }
         self.plugin.create_port(self.context, port_request)
 
+    def test_filter_subnet_after_subnet_deleted(self, *mocks):
+        fake_ip = '192.168.0.1'
+        fake_fixed_ips = [{
+            'subnet_id': uuidutils.generate_uuid(),
+            'ip_address': fake_ip
+        }]
+        filtered_ips = dns_integration._filter_by_subnet(self.context, fake_fixed_ips)
+        self.assertEqual(filtered_ips, [fake_ip])
+
     def test_dns_driver_loaded_after_server_restart(self, *mocks):
         dns_integration.DNS_DRIVER = None
         port, dns_data_db = self._create_port_for_test()


### PR DESCRIPTION
In case the port notification is handled after it related subnet was deleted,
an attribute error was rised. This commit will gracefully handle this case.