### PR TITLE
Fix policy enforcement for PUT resources

### DIFF
--- a/neutron/pecan_wsgi/hooks/policy_enforcement.py
+++ b/neutron/pecan_wsgi/hooks/policy_enforcement.py
@@ -52,7 +52,7 @@ def fetch_resource(method, neutron_context, controller,
             # handle the necessary logic.
             return
         field_list = [name for (name, value) in attrs.items()
-                      if (value.get('required_by_policy') or
+                      if (value.get('required_by_policy') or value.get('enforce_policy') or
                           value.get('primary_key') or 'default' not in value)]
     plugin = manager.NeutronManager.get_plugin_for_resource(collection)
     if plugin:


### PR DESCRIPTION
policy_enforcement is used by Neutron pecan as a pre- and post-hook of API requests,
for PUT (Update) requests, the fetch_resource() function fetches the resource objects
from database to evaluate the pre-update hook for correct attribute matches with the
oslo_policy rules. But by default, for PUT, it won't popuplate the resources with the enforce_policy
attribute set, although these attributes can be used in the policy rules.

As an example for port's attribute device_owner:
```
Unable to find requested field: device_owner in target: {'id': 'cc274759-747d-4b8f-9235-ac894e2609e4', 'network_id': '2468d563-1bef-4063-aec8-8650754ab71c', 'tenant_id': '1203ed96bbff4a9e8bf55b52843682d9', 'status': 'ACTIVE', 'dns_assignment': [{'ip_address': '10.180.0.57', 'hostname': 'host-10-180-0-57', 'fqdn': 'host-10-180-0-57.bla.'}], 'project_id': '1203ed96bbff4a9e8bf55b52843682d9', 'fixed_ips': [{'subnet_id': '858f0d2d-5622-4be2-abe6-e5a286bde3b7', 'ip_address': '10.180.0.57'}], 'attributes_to_update': ['fixed_ips']} _get_target_value /ussuri/neutron/neutron/policy.py:395
```

This is caused because for PUT requests the only attributes without default key, or with primary key or required_by_policy are filtered.

This patch also filters for resources that have the enforce_policy attribute set, e.g. from Readme:

```
``enforce_policy``          the attribute is actively part of the policy enforcing mechanism, ie: there might be rules which refer to this attribute
```