### PR TITLE
Do not set project_id for floating ip ports

### DIFF
--- a/neutron/db/l3_db.py
+++ b/neutron/db/l3_db.py
@@ -1361,8 +1361,7 @@ class L3_NAT_dbonly_mixin(l3.RouterPluginBase,
 
         self._core_plugin.update_port(
             context.elevated(), external_port['id'],
-            {'port': {'device_id': fip_id,
-                      'project_id': fip['tenant_id']}})
+            {'port': {'device_id': fip_id}})
         registry.notify(resources.FLOATING_IP,
                         events.AFTER_UPDATE,
                         self._update_fip_assoc,


### PR DESCRIPTION
Floating IP ports should not have a project_id assigned to them as they
are not managed by the owner of a project, but by OpenStack itself. With
a project_id assigned they also count towards the port quota of said
project, which they should not. Therefore, we do not set a project_id
anymore on Floating IP creation for the Floating IP port. This is in
line with the behaviour we currently have for gateway interfaces of
routers.

Change-Id: I053d48166141e5cdbd39a1235a43b06d64478bc1
Closes-Bug: #1949767

---

Upstream backport