### PR TITLE
Sync the dns-assignment with the actual designate dns-domain

### DIFF
--- a/neutron/plugins/ml2/extensions/dns_integration.py
+++ b/neutron/plugins/ml2/extensions/dns_integration.py
@@ -288,6 +288,8 @@ class DNSExtensionDriver(api.ExtensionDriver):
         if dns_domain and dns_domain != lib_const.DNS_DOMAIN_DEFAULT:
             if dns_data_db:
                 dns_name = dns_data_db.dns_name
+                if dns_data_db.current_dns_domain:
+                    dns_domain = dns_data_db.current_dns_domain
         return dns_name, dns_domain
 
     def _get_dns_names_for_port(self, ips, dns_data_db):

--- a/neutron/tests/unit/plugins/ml2/extensions/test_dns_integration.py
+++ b/neutron/tests/unit/plugins/ml2/extensions/test_dns_integration.py
@@ -164,6 +164,9 @@ class DNSIntegrationTestCase(test_plugin.Ml2PluginV2TestCase):
             self.assertEqual(current_dns_name, dns_data_db['current_dns_name'])
             self.assertEqual(previous_dns_name,
                              dns_data_db['previous_dns_name'])
+            curr_dns_domain = dns_data_db['current_dns_domain']
+            for fqdn in port['dns_assignment']:
+                self.assertTrue(fqdn['fqdn'].endswith(curr_dns_domain))
             if current_dns_name:
                 self.assertEqual(current_dns_domain,
                                  dns_data_db['current_dns_domain'])

--- a/releasenotes/notes/fix-port-dns-assignment-9d916d77522abd65.yaml
+++ b/releasenotes/notes/fix-port-dns-assignment-9d916d77522abd65.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    The dns-assignment will reflect the dns-domain defined in the network or
+    sent by user when creating the port using --dns-domain rather than just
+    take the dns-domain defined in the neutron configuration


### PR DESCRIPTION
When a port is created the dns-assignment (dns-domain part)
was always taken form Neutron config dns_domain which is not
always true, since it could be Neutron network dns_domain or
the dns_domain sent when creating the port

Change-Id: I7f4366ff5a26f73013433bfbfb299fd06294f359
Closes-Bug:1873091