### PR TITLE
[OVS] Fix live-migration connection disruption

### DIFF
--- a/neutron/conf/common.py
+++ b/neutron/conf/common.py
@@ -174,6 +174,24 @@ nova_opts = [
                help=_('Type of the nova endpoint to use.  This endpoint will'
                       ' be looked up in the keystone catalog and should be'
                       ' one of public, internal or admin.')),
+    cfg.BoolOpt('live_migration_events', default=False,
+                help=_('When this option is enabled, during the live '
+                       'migration, the OVS agent will only send the '
+                       '"vif-plugged-event" when the destination host '
+                       'interface is bound. This option also disables any '
+                       'other agent (like DHCP) to send to Nova this event '
+                       'when the port is provisioned.'
+                       'This option can be enabled if Nova patch '
+                       'https://review.opendev.org/c/openstack/nova/+/767368 '
+                       'is in place.'
+                       'This option is temporary and will be removed in Y and '
+                       'the behavior will be "True".'),
+                deprecated_for_removal=True,
+                deprecated_reason=(
+                    'In Y the Nova patch '
+                    'https://review.opendev.org/c/openstack/nova/+/767368 '
+                    'will be in the code even when running a Nova server in '
+                    'X.')),
 ]
 
 

--- a/neutron/db/provisioning_blocks.py
+++ b/neutron/db/provisioning_blocks.py
@@ -138,8 +138,7 @@ def provisioning_complete(context, object_id, object_type, entity):
             context, standard_attr_id=standard_attr_id):
         LOG.debug("Provisioning complete for %(otype)s %(oid)s triggered by "
                   "entity %(entity)s.", log_dict)
-        registry.publish(object_type, PROVISIONING_COMPLETE,
-                         'neutron.db.provisioning_blocks',
+        registry.publish(object_type, PROVISIONING_COMPLETE, entity,
                          payload=events.DBEventPayload(
                              context, resource_id=object_id))
 

--- a/neutron/plugins/ml2/drivers/openvswitch/agent/ovs_neutron_agent.py
+++ b/neutron/plugins/ml2/drivers/openvswitch/agent/ovs_neutron_agent.py
@@ -187,8 +187,8 @@ class OVSNeutronAgent(l2population_rpc.L2populationRpcCallBackTunnelMixin,
                         "DVR and tunneling are enabled, setting to True.")
             self.arp_responder_enabled = True
 
-        host = self.conf.host
-        self.agent_id = 'ovs-agent-%s' % host
+        self.host = self.conf.host
+        self.agent_id = 'ovs-agent-%s' % self.host
 
         # Validate agent configurations
         self._check_agent_configurations()
@@ -274,7 +274,7 @@ class OVSNeutronAgent(l2population_rpc.L2populationRpcCallBackTunnelMixin,
             self.phys_ofports,
             self.patch_int_ofport,
             self.patch_tun_ofport,
-            host,
+            self.host,
             self.enable_tunneling,
             self.enable_distributed_routing)
 
@@ -319,7 +319,7 @@ class OVSNeutronAgent(l2population_rpc.L2populationRpcCallBackTunnelMixin,
         #                  or which are used by specific extensions.
         self.agent_state = {
             'binary': 'neutron-openvswitch-agent',
-            'host': host,
+            'host': self.host,
             'topic': n_const.L2_AGENT_TOPIC,
             'configurations': {'bridge_mappings': self.bridge_mappings,
                                n_const.RP_BANDWIDTHS: self.rp_bandwidths,
@@ -1933,6 +1933,8 @@ class OVSNeutronAgent(l2population_rpc.L2populationRpcCallBackTunnelMixin,
         skipped_devices = []
         need_binding_devices = []
         binding_no_activated_devices = set()
+        devices_not_in_datapath = set()
+        migrating_devices = set()
         agent_restarted = self.iter_num == 0
         devices_details_list = (
             self.plugin_rpc.get_devices_details_list_and_failed_devices(
@@ -1957,6 +1959,15 @@ class OVSNeutronAgent(l2population_rpc.L2populationRpcCallBackTunnelMixin,
                 self.ext_manager.delete_port(self.context, {'port_id': device})
                 skipped_devices.append(device)
                 continue
+
+            if not port.ofport or port.ofport == ovs_lib.INVALID_OFPORT:
+                devices_not_in_datapath.add(device)
+
+            migrating_to = details.get('migrating_to')
+            if migrating_to and migrating_to != self.host:
+                LOG.info('Port %(device)s is being migrated to host %(host)s.',
+                         {'device': device, 'host': migrating_to})
+                migrating_devices.add(device)
 
             if 'port_id' in details:
                 LOG.info("Port %(device)s updated. Details: %(details)s",
@@ -1993,7 +2004,8 @@ class OVSNeutronAgent(l2population_rpc.L2populationRpcCallBackTunnelMixin,
                 if (port and port.ofport != -1):
                     self.port_dead(port)
         return (skipped_devices, binding_no_activated_devices,
-                need_binding_devices, failed_devices)
+                need_binding_devices, failed_devices, devices_not_in_datapath,
+                migrating_devices)
 
     def _update_port_network(self, port_id, network_id):
         self._clean_network_ports(port_id)
@@ -2087,10 +2099,13 @@ class OVSNeutronAgent(l2population_rpc.L2populationRpcCallBackTunnelMixin,
         need_binding_devices = []
         skipped_devices = set()
         binding_no_activated_devices = set()
+        devices_not_in_datapath = set()
+        migrating_devices = set()
         start = time.time()
         if devices_added_updated:
             (skipped_devices, binding_no_activated_devices,
-             need_binding_devices, failed_devices['added']) = (
+             need_binding_devices, failed_devices['added'],
+             devices_not_in_datapath, migrating_devices) = (
                 self.treat_devices_added_or_updated(
                     devices_added_updated, provisioning_needed, re_added))
             LOG.info("process_network_ports - iteration:%(iter_num)d - "
@@ -2113,7 +2128,7 @@ class OVSNeutronAgent(l2population_rpc.L2populationRpcCallBackTunnelMixin,
         # TODO(salv-orlando): Optimize avoiding applying filters
         # unnecessarily, (eg: when there are no IP address changes)
         added_ports = (port_info.get('added', set()) - skipped_devices -
-                       binding_no_activated_devices)
+                       binding_no_activated_devices - migrating_devices)
         self._add_port_tag_info(need_binding_devices)
 
         self.process_install_ports_egress_flows(need_binding_devices)

--- a/neutron/plugins/ml2/plugin.py
+++ b/neutron/plugins/ml2/plugin.py
@@ -87,6 +87,7 @@ from sqlalchemy import or_
 from sqlalchemy.orm import exc as sa_exc
 
 from neutron._i18n import _
+from neutron.agent import rpc as agent_rpc
 from neutron.agent import securitygroups_rpc as sg_rpc
 from neutron.api.rpc.agentnotifiers import dhcp_rpc_agent_api
 from neutron.api.rpc.handlers import dhcp_rpc
@@ -320,8 +321,19 @@ class Ml2Plugin(db_base_plugin_v2.NeutronDbPluginV2,
             LOG.debug("Port %s is administratively disabled so it will "
                       "not transition to active.", port_id)
             return
-        self.update_port_status(
-            payload.context, port_id, const.PORT_STATUS_ACTIVE)
+
+        host_migrating = agent_rpc.migrating_to_host(
+            getattr(port, 'port_bindings', []))
+        if (host_migrating and cfg.CONF.nova.live_migration_events and
+                self.nova_notifier):
+            send_nova_event = bool(trigger ==
+                                   provisioning_blocks.L2_AGENT_ENTITY)
+            with self.nova_notifier.context_enabled(send_nova_event):
+                self.update_port_status(payload.context, port_id,
+                                        const.PORT_STATUS_ACTIVE)
+        else:
+            self.update_port_status(payload.context, port_id,
+                                    const.PORT_STATUS_ACTIVE)
 
     @log_helpers.log_method_call
     def _start_rpc_notifiers(self):

--- a/neutron/tests/unit/plugins/ml2/drivers/openvswitch/agent/test_ovs_neutron_agent.py
+++ b/neutron/tests/unit/plugins/ml2/drivers/openvswitch/agent/test_ovs_neutron_agent.py
@@ -883,7 +883,7 @@ class TestOvsNeutronAgent(object):
                     'get_port_tag_dict',
                     return_value={}),\
                 mock.patch.object(self.agent, func_name) as func:
-            skip_devs, _, need_bound_devices, _ = (
+            skip_devs, _, need_bound_devices, _, _, _ = (
                 self.agent.treat_devices_added_or_updated([], False, set()))
             # The function should not raise
             self.assertFalse(skip_devs)
@@ -901,7 +901,7 @@ class TestOvsNeutronAgent(object):
                                   'get_vifs_by_ids',
                                   return_value={details['device']: port}),\
                 mock.patch.object(self.agent, 'port_dead') as func:
-            skip_devs, binding_no_activated_devices, _, _ = (
+            skip_devs, binding_no_activated_devices, _, _, _, _ = (
                 self.agent.treat_devices_added_or_updated([], False, set()))
             self.assertFalse(skip_devs)
             self.assertTrue(func.called)
@@ -978,8 +978,9 @@ class TestOvsNeutronAgent(object):
                 [], False, set())
             # The function should return False for resync and no device
             # processed
-            self.assertEqual((['the_skipped_one'], set(), [], set()),
-                             skip_devs)
+            self.assertEqual(
+                (['the_skipped_one'], set(), [], set(), set(), set()),
+                skip_devs)
             ext_mgr_delete_port.assert_called_once_with(
                 self.agent.context, {'port_id': 'the_skipped_one'})
             treat_vif_port.assert_not_called()
@@ -996,7 +997,7 @@ class TestOvsNeutronAgent(object):
                 mock.patch.object(self.agent,
                                   'treat_vif_port') as treat_vif_port:
             failed_devices = {'added': set(), 'removed': set()}
-            (_, _, _, failed_devices['added']) = (
+            (_, _, _, failed_devices['added'], _, _) = (
                 self.agent.treat_devices_added_or_updated([], False, set()))
             # The function should return False for resync and no device
             # processed
@@ -1027,7 +1028,7 @@ class TestOvsNeutronAgent(object):
                                   return_value={}),\
                 mock.patch.object(self.agent,
                                   'treat_vif_port') as treat_vif_port:
-            skip_devs, _, need_bound_devices, _ = (
+            skip_devs, _, need_bound_devices, _, _, _ = (
                 self.agent.treat_devices_added_or_updated([], False, set()))
             # The function should return False for resync
             self.assertFalse(skip_devs)
@@ -1136,7 +1137,8 @@ class TestOvsNeutronAgent(object):
                     self.agent, "treat_devices_added_or_updated",
                     return_value=(
                         skipped_devices, binding_no_activated_devices, [],
-                        failed_devices['added'])) as device_added_updated,\
+                        failed_devices['added'],
+                        set(), set())) as device_added_updated,\
                 mock.patch.object(self.agent.int_br, "get_ports_attributes",
                                   return_value=[]),\
                 mock.patch.object(self.agent,

--- a/zuul.d/tempest-multinode.yaml
+++ b/zuul.d/tempest-multinode.yaml
@@ -130,6 +130,11 @@
         s-container: false
         s-object: false
         s-proxy: false
+      devstack_local_conf:
+        post-config:
+          $NEUTRON_CONF:
+            nova:
+              live_migration_events: True
     group-vars:
       subnode:
         devstack_localrc:


### PR DESCRIPTION
The goal of this patch is to avoid the connection disruption during
the live-migration using OVS. Since [1], when a port is migrated,
both the source and the destination hosts are added to the profile
binding information. Initially, the source host binding is activated
and the destination is deactivated.

When the port is created in the destination host (created by Nova),
the port was not configured because the binding was not activated.
The binding (that means, all the OpenFlow rules) was done when Nova
sent the port activation. That happend when the VM was already
running in the destination host. If the OVS agent was loaded, the
port was bound seconds later to the port activation.

Instead, this patch enables the OpenFlow rule creation in the
destination host when the port is created.

Another problem are the "neutron-vif-plugged" events sent by Neutron
to Nova to inform about the port binding. Nova is expecting one single
event informing about the destination port binding. At this moment,
Nova considers the port is bound and ready to transmit data.

Several triggers were firing expectedly this event:
- When the port binding was updated, the port is set to down and then
  up again, forcing this event.
- When the port binding was updated, first the binding is deleted and
  then updated with the new information. That triggers in the source
  host to set the port down and the up again, sending the event.

This patch removes those events, sending the "neutron-vif-plugged"
event only when the port is bound to the destination host (and as
commented before, this is happening now regardless of the binding
activation status).

This feature depends on [2]. If this Nova patch is not in place, Nova
will never plug the port in the destination host and Neutron won't be
able to send the vif-plugged event to Nova to finish the
live-migration process.

Because from Neutron cannot query Nova to know if this patch is in
place, a new temporary configuration option has been created to enable
this feature. The default value will be "False"; that means Neutron
will behave as before.

[1]https://bugs.launchpad.net/neutron/+bug/1580880
[2]https://review.opendev.org/c/openstack/nova/+/767368

Closes-Bug: #1901707

Change-Id: Iee323943ac66e566e5a5e92de1861832e86fc7fc