### PR TITLE
[pep8] Fix overlong lines in agent code

### DIFF
--- a/neutron/agent/linux/ip_lib.py
+++ b/neutron/agent/linux/ip_lib.py
@@ -1392,10 +1392,10 @@ def get_devices_info(namespace, attrs=None, **kwargs):
                      'IFLA_VXLAN_ID'],
         'vxlan_group': ['IFLA_LINKINFO', 'IFLA_INFO_KIND', 'IFLA_INFO_DATA',
                         'IFLA_VXLAN_GROUP'],
-        'vxlan_link_index': ['IFLA_LINKINFO', 'IFLA_INFO_KIND', 'IFLA_INFO_DATA',
-                             'IFLA_VXLAN_LINK'],
-        'vxlan_link_name': ['IFLA_LINKINFO', 'IFLA_INFO_KIND', 'IFLA_INFO_DATA',
-                            'IFLA_VXLAN_LINK'],
+        'vxlan_link_index': ['IFLA_LINKINFO', 'IFLA_INFO_KIND',
+                             'IFLA_INFO_DATA', 'IFLA_VXLAN_LINK'],
+        'vxlan_link_name': ['IFLA_LINKINFO', 'IFLA_INFO_KIND',
+                            'IFLA_INFO_DATA', 'IFLA_VXLAN_LINK'],
     }
     attr_filter = set()
     if attrs is not None:

--- a/neutron/privileged/agent/linux/ip_lib.py
+++ b/neutron/privileged/agent/linux/ip_lib.py
@@ -610,7 +610,8 @@ def get_device_names(namespace, **kwargs):
     """
     devices_attrs = [link['attrs'] for link
                      in get_link_devices(namespace,
-                                         attr_filter=['IFLA_IFNAME'], **kwargs)]
+                                         attr_filter=['IFLA_IFNAME'],
+                                         **kwargs)]
     device_names = []
     for device_attrs in devices_attrs:
         for link_name in (link_attr[1] for link_attr in device_attrs


### PR DESCRIPTION
As OpenStack does <80 chars per line, so do we in our Neutron fork.