### PR TITLE
Fix wrong fields in get_devices_info() for linuxbridge

### DIFF
--- a/neutron/agent/linux/ip_lib.py
+++ b/neutron/agent/linux/ip_lib.py
@@ -1386,7 +1386,7 @@ def get_devices_info(namespace, attrs=None, **kwargs):
         'parent_index': ['IFLA_LINK', 'IFLA_LINKINFO'],
         'parent_name': ['IFLA_LINK', 'IFLA_LINKINFO'],
         'kind': ['IFLA_LINKINFO', 'IFLA_INFO_KIND'],
-        'vlan_id': ['IFLA_LINKINFO', 'IFLA_INFO_KIND' 'IFLA_INFO_DATA',
+        'vlan_id': ['IFLA_LINKINFO', 'IFLA_INFO_KIND', 'IFLA_INFO_DATA',
                     'IFLA_VLAN_ID'],
         'vxlan_id': ['IFLA_LINKINFO', 'IFLA_INFO_KIND', 'IFLA_INFO_DATA',
                      'IFLA_VXLAN_ID'],


### PR DESCRIPTION
A missing ',' merged two fields in get_devices_info(), causing the
fields to be missing from the resulting dictionary.