### PR TITLE
Only set address scope when present for l3 sync data

### DIFF
--- a/neutron/db/l3_db.py
+++ b/neutron/db/l3_db.py
@@ -1786,9 +1786,7 @@ class L3_NAT_dbonly_mixin(l3.RouterPluginBase,
 
             scopes = {}
             for subnet in subnets_by_network[port['network_id']]:
-                scope = subnet['address_scope_id']
                 cidr = netaddr.IPNetwork(subnet['cidr'])
-                scopes[cidr.version] = scope
 
                 # If this subnet is used by the port (has a matching entry
                 # in the port's fixed_ips), then add this subnet to the
@@ -1802,6 +1800,7 @@ class L3_NAT_dbonly_mixin(l3.RouterPluginBase,
                                'subnetpool_id': subnet['subnetpool_id']}
                 for fixed_ip in port['fixed_ips']:
                     if fixed_ip['subnet_id'] == subnet['id']:
+                        scopes[cidr.version] = subnet['address_scope_id']
                         port['subnets'].append(subnet_info)
                         prefixlen = cidr.prefixlen
                         fixed_ip['prefixlen'] = prefixlen

--- a/neutron/tests/unit/db/test_l3_db.py
+++ b/neutron/tests/unit/db/test_l3_db.py
@@ -150,6 +150,41 @@ class TestL3_NAT_dbonly_mixin(base.BaseTestCase):
                                'subnets': [{k: subnet[k] for k in keys}],
                                'address_scopes': address_scopes}], ports)
 
+    @mock.patch.object(l3_db.L3_NAT_dbonly_mixin,
+                       '_get_subnets_by_network_list')
+    def test__populate_ports_for_subnets_mixed_address_scopes(
+            self, get_subnets_by_network):
+        subnets = [{'id': mock.sentinel.subnet_id_a,
+                    'cidr': '10.180.0.0/24',
+                    'gateway_ip': mock.sentinel.gateway_ip_a,
+                    'dns_nameservers': mock.sentinel.dns_nameservers_a,
+                    'ipv6_ra_mode': mock.sentinel.ipv6_ra_mode_a,
+                    'subnetpool_id': mock.sentinel.subnetpool_id,
+                    'address_scope_id': mock.sentinel.address_scope_id},
+                   {'id': mock.sentinel.subnet_id_b,
+                    'cidr': '10.180.1.0/24',
+                    'gateway_ip': mock.sentinel.gateway_ip_b,
+                    'dns_nameservers': mock.sentinel.dns_nameservers_b,
+                    'ipv6_ra_mode': mock.sentinel.ipv6_ra_mode_b,
+                    'subnetpool_id': None,
+                    'address_scope_id': None}]
+        get_subnets_by_network.return_value = {'net_id': subnets}
+
+        ports = [{'network_id': 'net_id',
+                  'id': 'port_id_a',
+                  'fixed_ips': [{'subnet_id': mock.sentinel.subnet_id_a}]},
+                 {'network_id': 'net_id',
+                  'id': 'port_id_b',
+                  'fixed_ips': [{'subnet_id': mock.sentinel.subnet_id_b}]}]
+        with mock.patch.object(directory, 'get_plugin') as get_p:
+            get_p().get_networks.return_value = [{'id': 'net_id', 'mtu': 1446}]
+            self.db._populate_mtu_and_subnets_for_ports(mock.sentinel.context,
+                                                        ports)
+
+            self.assertEqual(mock.sentinel.address_scope_id,
+                             ports[0]['address_scopes'][n_const.IP_VERSION_4])
+            self.assertIsNone(ports[1]['address_scopes'][n_const.IP_VERSION_4])
+
     def test__get_sync_floating_ips_no_query(self):
         """Basic test that no query is performed if no router ids are passed"""
         db = l3_db.L3_NAT_dbonly_mixin()


### PR DESCRIPTION
Upstream Neutron has the assumption that all subnets of a network are in
the same subnet pool (and therefore same address scope), while our brand
of Neutron requires all subnets in a network to be either in the same
address scope or in no address scope at all.

Neutron adds the address scope to each port in the l3 router sync data,
but looks at all subnets present in the network. We now change this
behavior to only add the address scope when the router port is actually
in a subnet with this address scope. With this DAPNets (Directly
Accessible Private Networks) and non-DAPNets can live in peace together.