### PR TITLE
mac address uniq

### DIFF
--- a/neutron/db/db_base_plugin_common.py
+++ b/neutron/db/db_base_plugin_common.py
@@ -109,7 +109,7 @@ class DbBasePluginCommon(object):
 
     @db_api.CONTEXT_READER
     def _is_mac_in_use(self, context, network_id, mac_address):
-        return port_obj.Port.objects_exist(context, network_id=network_id,
+        return port_obj.Port.objects_exist(context,
                                            mac_address=mac_address)
 
     @staticmethod

--- a/neutron/db/db_base_plugin_v2.py
+++ b/neutron/db/db_base_plugin_v2.py
@@ -1396,7 +1396,12 @@ class NeutronDbPluginV2(db_base_plugin_common.DbBasePluginCommon,
                 raise exc.MacAddressInUse(net_id=port_data['network_id'],
                                           mac=mac_address)
         else:
-            mac_address = self._generate_macs()[0]
+            while True:
+                mac_address = self._generate_macs()[0]
+                if not self._is_mac_in_use(context, port_data['network_id'],
+                                           mac_address):
+                    break
+
         db_port = models_v2.Port(mac_address=mac_address, **port_data)
         context.session.add(db_port)
         return db_port

--- a/neutron/tests/unit/db/test_db_base_plugin_v2.py
+++ b/neutron/tests/unit/db/test_db_base_plugin_v2.py
@@ -1899,7 +1899,7 @@ fixed_ips=ip_address%%3D%s&fixed_ips=ip_address%%3D%s&fixed_ips=subnet_id%%3D%s
             mac2 = '00:22:00:44:00:66'  # other mac, same network
             self.assertFalse(self.plugin._is_mac_in_use(ctx, net_id, mac2))
             net_id2 = port['port']['id']  # other net uuid, same mac
-            self.assertFalse(self.plugin._is_mac_in_use(ctx, net_id2, mac))
+            self.assertTrue(self.plugin._is_mac_in_use(ctx, net_id2, mac))
 
     def test_requested_duplicate_ip(self):
         with self.subnet() as subnet:


### PR DESCRIPTION
- [_create_db_port_obj] re-generate mac address if collision is detected
- [db_base_plugin_common] allocate mac_address uniquely across all networks
