### PR TITLE
Relax check on subnet pools to just satisfy same address scope

### DIFF
--- a/neutron/db/ipam_backend_mixin.py
+++ b/neutron/db/ipam_backend_mixin.py
@@ -266,10 +266,9 @@ class IpamBackendMixin(db_base_plugin_common.DbBasePluginCommon):
 
     def _validate_network_subnetpools(self, network, subnet_ip_version,
                                       new_subnetpool, network_scope):
-        """Validate all subnets on the given network have been allocated from
-           the same subnet pool as new_subnetpool if no address scope is
-           used. If address scopes are used, validate that all subnets on the
-           given network participate in the same address scope.
+        """If address scopes are used, validate that all subnets on the
+           given network participate in the same address scope or have no
+           subnet pool set.
         """
         # 'new_subnetpool' might just be the Prefix Delegation ID
         ipv6_pd_subnetpool = new_subnetpool == const.IPV6_PD_POOL_ID
@@ -290,13 +289,10 @@ class IpamBackendMixin(db_base_plugin_common.DbBasePluginCommon):
                         subnet.subnetpool_id != const.IPV6_PD_POOL_ID):
                     raise exc.NetworkSubnetPoolAffinityError()
             else:
-                if new_subnetpool:
-                    # In this case we have the new subnetpool object, so
-                    # we can check the ID and IP version.
-                    if (subnet.subnetpool_id != new_subnetpool.id and
-                            subnet.ip_version == new_subnetpool.ip_version and
-                            not network_scope):
-                        raise exc.NetworkSubnetPoolAffinityError()
+                if (subnet.ip_version == const.IP_VERSION_6 and
+                        subnet.subnetpool_id == const.IPV6_PD_POOL_ID and
+                        not ipv6_pd_subnetpool):
+                    raise exc.NetworkSubnetPoolAffinityError()
 
     def validate_allocation_pools(self, ip_pools, subnet_cidr):
         """Validate IP allocation pools.

--- a/neutron/tests/unit/db/test_ipam_backend_mixin.py
+++ b/neutron/tests/unit/db/test_ipam_backend_mixin.py
@@ -17,7 +17,6 @@ import mock
 import netaddr
 from neutron_lib.api.definitions import portbindings
 from neutron_lib import constants
-from neutron_lib import exceptions as exc
 from neutron_lib.exceptions import address_scope as addr_scope_exc
 from oslo_utils import uuidutils
 import webob.exc
@@ -326,19 +325,27 @@ class TestIpamBackendMixin(base.BaseTestCase):
                           subnetpool,
                           address_scope)
 
-    def test__validate_network_subnetpools_subnetpool_mismatch(self):
+    def test__validate_network_subnetpools_new_subnetpool(self):
         subnet = mock.MagicMock(ip_version=constants.IP_VERSION_4)
         subnet.subnetpool_id = 'fake-subnetpool'
         network = mock.MagicMock(subnets=[subnet])
         subnetpool = mock.MagicMock(id=uuidutils.generate_uuid())
         subnetpool.ip_version = constants.IP_VERSION_4
+        self.mixin._validate_network_subnetpools(
+            network,
+            constants.IP_VERSION_4,
+            subnetpool,
+            None)
 
-        self.assertRaises(exc.NetworkSubnetPoolAffinityError,
-                          self.mixin._validate_network_subnetpools,
-                          network,
-                          constants.IP_VERSION_4,
-                          subnetpool,
-                          None)
+    def test__validate_network_subnetpools_new_subnet_no_subnetpool(self):
+        address_scope_id = "dummy-scope"
+        address_scope = mock.MagicMock()
+        address_scope.id.return_value = address_scope_id
+        self.mixin._validate_network_subnetpools(
+            mock.MagicMock(),
+            constants.IP_VERSION_4,
+            None,
+            address_scope)
 
 
 class TestPlugin(db_base_plugin_v2.NeutronDbPluginV2,


### PR DESCRIPTION
The current implementation does not allow subnets from different address
scopes in a network. For DAPnets we need to relax that constraint so we
allow subnets from the same address scope as well as subnets with no
subnet pool (and hence no address scope) and subnets with the same
address scope in a network.