### PR TITLE
Mac address must only be globally unique on create

### DIFF
--- a/neutron/db/db_base_plugin_common.py
+++ b/neutron/db/db_base_plugin_common.py
@@ -108,9 +108,12 @@ class DbBasePluginCommon(object):
         return [six.next(mac_maker) for x in range(mac_count)]
 
     @db_api.CONTEXT_READER
-    def _is_mac_in_use(self, context, network_id, mac_address):
-        return port_obj.Port.objects_exist(context, network_id=network_id,
-                                           mac_address=mac_address)
+    def _is_mac_in_use(self, context, network_id, mac_address,
+                       globally_unique=False):
+        kwargs = dict(mac_address=mac_address)
+        if not globally_unique:
+            kwargs['network_id'] = network_id
+        return port_obj.Port.objects_exist(context, **kwargs)
 
     @staticmethod
     def _delete_ip_allocation(context, network_id, subnet_id, ip_address):

--- a/neutron/db/db_base_plugin_common.py
+++ b/neutron/db/db_base_plugin_common.py
@@ -109,7 +109,7 @@ class DbBasePluginCommon(object):
 
     @db_api.CONTEXT_READER
     def _is_mac_in_use(self, context, network_id, mac_address):
-        return port_obj.Port.objects_exist(context,
+        return port_obj.Port.objects_exist(context, network_id=network_id,
                                            mac_address=mac_address)
 
     @staticmethod

--- a/neutron/db/db_base_plugin_v2.py
+++ b/neutron/db/db_base_plugin_v2.py
@@ -1392,14 +1392,14 @@ class NeutronDbPluginV2(db_base_plugin_common.DbBasePluginCommon,
         mac_address = port_data.pop('mac_address', None)
         if mac_address:
             if self._is_mac_in_use(context, port_data['network_id'],
-                                   mac_address):
+                                   mac_address, globally_unique=True):
                 raise exc.MacAddressInUse(net_id=port_data['network_id'],
                                           mac=mac_address)
         else:
             while True:
                 mac_address = self._generate_macs()[0]
                 if not self._is_mac_in_use(context, port_data['network_id'],
-                                           mac_address):
+                                           mac_address, globally_unique=True):
                     break
 
         db_port = models_v2.Port(mac_address=mac_address, **port_data)

--- a/neutron/plugins/ml2/plugin.py
+++ b/neutron/plugins/ml2/plugin.py
@@ -1476,7 +1476,8 @@ class Ml2Plugin(db_base_plugin_v2.NeutronDbPluginV2,
                     const.ATTR_NOT_SPECIFIED)
                 if raw_mac_address is const.ATTR_NOT_SPECIFIED:
                     raw_mac_address = macs.pop()
-                elif self._is_mac_in_use(context, network_id, raw_mac_address):
+                elif self._is_mac_in_use(context, network_id, raw_mac_address,
+                                         globally_unique=True):
                     raise exc.MacAddressInUse(net_id=network_id,
                                               mac=raw_mac_address)
                 eui_mac_address = netaddr.EUI(raw_mac_address,

--- a/neutron/tests/unit/db/test_db_base_plugin_v2.py
+++ b/neutron/tests/unit/db/test_db_base_plugin_v2.py
@@ -1899,7 +1899,7 @@ fixed_ips=ip_address%%3D%s&fixed_ips=ip_address%%3D%s&fixed_ips=subnet_id%%3D%s
             mac2 = '00:22:00:44:00:66'  # other mac, same network
             self.assertFalse(self.plugin._is_mac_in_use(ctx, net_id, mac2))
             net_id2 = port['port']['id']  # other net uuid, same mac
-            self.assertTrue(self.plugin._is_mac_in_use(ctx, net_id2, mac))
+            self.assertFalse(self.plugin._is_mac_in_use(ctx, net_id2, mac))
 
     def test_requested_duplicate_ip(self):
         with self.subnet() as subnet:


### PR DESCRIPTION
The Cisco IOS XE platform drops any frames with a mac address that it has bound
on a local interface, no matter which VRF they are in. Openstack generates mac
addresses randomly and checks onlyh if the address is already used in the
current network. We implemented global mac address duplicate checking in
1a58780b81, but had to notice that ironic baremetal deployments may generate 2
ports in different subnets with the same IP. However this is only done on an
update and an update is an admin only action. Hence we relax the check for
update operations to only be network-wise unique while the create check must
satisfy a globally unique constraint.