### PR TITLE
register security_group/_rule resource manually in ml2 __init__ method

### DIFF
--- a/neutron/plugins/ml2/plugin.py
+++ b/neutron/plugins/ml2/plugin.py
@@ -247,6 +247,11 @@ class Ml2Plugin(db_base_plugin_v2.NeutronDbPluginV2,
         self.type_manager = managers.TypeManager()
         self.extension_manager = managers.ExtensionManager()
         self.mechanism_manager = managers.MechanismManager()
+        # Register these resources before the relevant extensions are loaded
+        # to prevent failures due to QuotaResourceUnknown error while creating
+        # default security group
+        resource_registry.register_resource_by_name('security_group')
+        resource_registry.register_resource_by_name('security_group_rule')
         super(Ml2Plugin, self).__init__()
         self.type_manager.initialize()
         self.extension_manager.initialize()


### PR DESCRIPTION
This is a quick&dirty solution to the missing security_group_rule quota resource
which can cause a quota exception when used in neutron-rpc-server, e.g.

`neutron_lib.callbacks.exceptions.CallbackFailure: Callback neutron.plugins.ml2.plugin.SecurityGroupDbMixin._ensure_default_security_group_handler-2184380 failed with "Unknown quota resources ['security_group_rule']."`

blatantly c&p from https://opendev.org/x/vmware-nsx/src/branch/master/vmware_nsx/plugins/nsx_v3/plugin.py#L176-L180
