### PR TITLE
allow manila ports to do multiple port binding for ML2

### DIFF
--- a/neutron/plugins/ml2/plugin.py
+++ b/neutron/plugins/ml2/plugin.py
@@ -2327,11 +2327,12 @@ class Ml2Plugin(db_base_plugin_v2.NeutronDbPluginV2,
             self.mechanism_manager.update_network_postcommit(mech_context)
 
     @staticmethod
-    def _validate_compute_port(port):
-        if not port['device_owner'].startswith(
-                const.DEVICE_OWNER_COMPUTE_PREFIX):
+    def _validate_compute_or_fileshare_port(port):
+        if not port['device_owner'].startswith((
+                const.DEVICE_OWNER_COMPUTE_PREFIX,
+                const.DEVICE_OWNER_MANILA_PREFIX)):
             msg = _('Invalid port %s. Operation only valid on compute '
-                    'ports') % port['id']
+                    'and manila ports') % port['id']
             raise exc.BadRequest(resource='port', msg=msg)
 
     def _make_port_binding_dict(self, binding, fields=None):
@@ -2373,7 +2374,7 @@ class Ml2Plugin(db_base_plugin_v2.NeutronDbPluginV2,
         attrs = binding[pbe_ext.RESOURCE_NAME]
         with db_api.CONTEXT_WRITER.using(context):
             port_db = self._get_port(context, port_id)
-            self._validate_compute_port(port_db)
+            self._validate_compute_or_fileshare_port(port_db)
             if self._get_binding_for_host(port_db.port_bindings,
                                           attrs[pbe_ext.HOST]):
                 raise exc.PortBindingAlreadyExists(
@@ -2421,7 +2422,7 @@ class Ml2Plugin(db_base_plugin_v2.NeutronDbPluginV2,
         port = ports_obj.Port.get_object(context, id=port_id)
         if not port:
             raise exc.PortNotFound(port_id=port_id)
-        self._validate_compute_port(port)
+        self._validate_compute_or_fileshare_port(port)
         filters = filters or {}
         pager = base_obj.Pager(sorts, limit, page_reverse, marker)
         bindings = ports_obj.PortBinding.get_objects(
@@ -2436,7 +2437,7 @@ class Ml2Plugin(db_base_plugin_v2.NeutronDbPluginV2,
         port = ports_obj.Port.get_object(context, id=port_id)
         if not port:
             raise exc.PortNotFound(port_id=port_id)
-        self._validate_compute_port(port)
+        self._validate_compute_or_fileshare_port(port)
         binding = ports_obj.PortBinding.get_object(context, host=host,
                                                    port_id=port_id)
         if not binding:
@@ -2454,7 +2455,7 @@ class Ml2Plugin(db_base_plugin_v2.NeutronDbPluginV2,
         attrs = binding[pbe_ext.RESOURCE_NAME]
         with db_api.CONTEXT_WRITER.using(context):
             port_db = self._get_port(context, port_id)
-            self._validate_compute_port(port_db)
+            self._validate_compute_or_fileshare_port(port_db)
             original_binding = self._get_binding_for_host(
                 port_db.port_bindings, host)
             if not original_binding:
@@ -2491,7 +2492,7 @@ class Ml2Plugin(db_base_plugin_v2.NeutronDbPluginV2,
             if isinstance(port_id, dict):
                 port_id = port_id['port_id']
             port_db = self._get_port(context, port_id)
-            self._validate_compute_port(port_db)
+            self._validate_compute_or_fileshare_port(port_db)
             active_binding = p_utils.get_port_binding_by_status_and_host(
                 port_db.port_bindings, const.ACTIVE)
             if host == (active_binding and active_binding.host):


### PR DESCRIPTION
The feature was added for nova live migration
(see https://review.opendev.org/c/openstack/neutron/+/414251/74/neutron/plugins/ml2/plugin.py#2005). Manila wants to do share live migration, and needs to modify its ports in a similar fashion: issue port binding upfront to determine the segmentation id in the target network segment.

depends on [new constant 'DEVICE_OWNER_MANILA_PREFIX' in neutron-lib](https://github.com/sapcc/neutron-lib/pull/2)