### PR TITLE
[CCC-34286] Do not fail on port deletion if dns_name and dns_port are…

### DIFF
--- a/neutron/services/externaldns/drivers/designate/driver.py
+++ b/neutron/services/externaldns/drivers/designate/driver.py
@@ -41,7 +41,7 @@ extdns_designate_driver.register_designate_opts()
 LOG = log.getLogger(__name__)
 
 
-def get_clients(context):
+def get_clients(context, all_projects=False, edit_managed=False):
     global _SESSION
 
     if not _SESSION:
@@ -61,13 +61,19 @@ def get_clients(context):
             tenant_name=CONF.designate.admin_tenant_name,
             tenant_id=CONF.designate.admin_tenant_id)
     admin_client = d_client.Client(session=_SESSION, auth=admin_auth,
-                                   endpoint_override=CONF.designate.url)
+                                   endpoint_override=CONF.designate.url,
+                                   all_projects=all_projects,
+                                   edit_managed=edit_managed)
     return client, admin_client
 
 
 def get_all_projects_client(context):
     auth = token_endpoint.Token(CONF.designate.url, context.auth_token)
     return d_client.Client(session=_SESSION, auth=auth, all_projects=True)
+
+
+def get_all_projects_edit_managed_client(context):
+    return get_clients(context, all_projects=True, edit_managed=True)
 
 
 class Designate(driver.ExternalDNSService):
@@ -168,24 +174,53 @@ class Designate(driver.ExternalDNSService):
 
     def delete_record_set(self, context, dns_domain, dns_name, records):
         client, admin_client = get_clients(context)
+        ids_to_delete = []
         try:
+            # first try regular client:
             ids_to_delete = self._get_ids_ips_to_delete(
                 dns_domain, '%s.%s' % (dns_name, dns_domain), records, client)
-        except dns_exc.DNSDomainNotFound:
+        except (dns_exc.DNSDomainNotFound, d_exc.Forbidden):
             # Try whether we have admin powers and can see all projects
-            client = get_all_projects_client(context)
-            ids_to_delete = self._get_ids_ips_to_delete(
-                dns_domain, '%s.%s' % (dns_name, dns_domain), records, client)
+            # and also handle managed records (to prevent leftover PTRs):
+            client, admin_client = get_all_projects_edit_managed_client(
+                context)
+            try:
+                ids_to_delete = self._get_ids_ips_to_delete(
+                    dns_domain,
+                    '%s.%s' % (dns_name, dns_domain),
+                    records,
+                    admin_client)
+            except d_exc.Forbidden:
+                LOG.error("Cannot determine Designate record ids for "
+                          "deletion of: '%(name)s.%(dom)s'",
+                          {'name': dns_name, 'dom': dns_domain})
+            except dns_exc.DNSDomainNotFound:
+                LOG.debug("The domain '%s' not found in Designate",
+                          dns_domain)
 
         for _id in ids_to_delete:
-            client.recordsets.delete(dns_domain, _id)
+            try:
+                client.recordsets.delete(dns_domain, _id)
+            except d_exc.Forbidden:
+                LOG.error("Cannot delete Designate record with id %(recid)s in"
+                          " domain: %(dom)s",
+                          {'recid': _id, 'dom': dns_domain})
+
         if not CONF.designate.allow_reverse_dns_lookup:
             return
 
         for record in records:
-            in_addr_name = netaddr.IPAddress(record).reverse_dns
-            in_addr_zone_name = self._get_in_addr_zone_name(in_addr_name)
-            admin_client.recordsets.delete(in_addr_zone_name, in_addr_name)
+            try:
+                in_addr_name = netaddr.IPAddress(record).reverse_dns
+                in_addr_zone_name = self._get_in_addr_zone_name(in_addr_name)
+                admin_client.recordsets.delete(in_addr_zone_name,
+                                               in_addr_name)
+            except (dns_exc.DNSDomainNotFound, d_exc.NotFound):
+                LOG.debug("No '%s' PTR record was found in Designate.",
+                          in_addr_name)
+            except d_exc.Forbidden:
+                LOG.error("Cannot delete '%s' PTR record.",
+                          in_addr_name)
 
     def _get_ids_ips_to_delete(self, dns_domain, name, records,
                                designate_client):


### PR DESCRIPTION
… set.

In case a port has dns_name and dns_domain set, Neutron will attempt to find the respective dns records for forward and reverse lookups in Designate.

Since many zones are shared and kept in admin domain, regular non-admin users cannot search and delete those. We only want to log such events and not fail deletion request with Forbidden response from Designate.

Additionally, in case FIP reverse PTR record was created as managed (after allocation), we need to allow deletion of those when creating client.