### PR TITLE
Make Neutron ready for tox4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,4 +26,5 @@ except ImportError:
 
 setuptools.setup(
     setup_requires=['pbr>=2.0.0'],
-    pbr=True)
+    pbr=True,
+    py_modules=[])

--- a/tox.ini
+++ b/tox.ini
@@ -90,7 +90,7 @@ deps = {[testenv:dsvm-fullstack]deps}
 commands =
   {toxinidir}/tools/generate_dhclient_script_for_fullstack.sh {envdir}
   {toxinidir}/tools/deploy_rootwrap.sh {toxinidir} {envdir}/etc {envdir}/bin
-  stestr run --concurrency 2 --black-regex neutron.tests.fullstack.test_securitygroup.TestSecurityGroupsSameNetwork.test_securitygroup {posargs}
+  stestr run --concurrency 2 --exclude-regex neutron.tests.fullstack.test_securitygroup.TestSecurityGroupsSameNetwork.test_securitygroup {posargs}
   stestr run --combine --concurrency 1 neutron.tests.fullstack.test_securitygroup.TestSecurityGroupsSameNetwork.test_securitygroup {posargs}
 
 [testenv:releasenotes]

--- a/tox.ini
+++ b/tox.ini
@@ -12,16 +12,24 @@ setenv = VIRTUAL_ENV={envdir}
          OS_STDERR_CAPTURE={env:OS_STDERR_CAPTURE:true}
          OS_TEST_TIMEOUT={env:OS_TEST_TIMEOUT:180}
          PYTHONWARNINGS=default::DeprecationWarning,ignore::DeprecationWarning:distutils,ignore::DeprecationWarning:site
-passenv = TRACE_FAILONLY GENERATE_HASHES http_proxy HTTP_PROXY https_proxy HTTPS_PROXY no_proxy NO_PROXY TOX_ENV_SRC_MODULES
+passenv = TRACE_FAILONLY
+          GENERATE_HASHES
+          http_proxy
+          HTTP_PROXY
+          https_proxy
+          HTTPS_PROXY
+          no_proxy
+          NO_PROXY
+          TOX_ENV_SRC_MODULES
 usedevelop = True
 deps =
   -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/yoga}
   -r{toxinidir}/requirements.txt
   -r{toxinidir}/test-requirements.txt
   hacking>=3.0.1,<3.1.0 # Apache-2.0
-allowlist_externals = sh
+allowlist_externals = bash
 commands =
-  {toxinidir}/tools/pip_install_src_modules.sh "{toxinidir}"
+  bash {toxinidir}/tools/pip_install_src_modules.sh "{toxinidir}"
   stestr run {posargs}
 
 # there is also secret magic in ostestr which lets you run in a fail only
@@ -63,7 +71,7 @@ setenv = {[testenv:functional]setenv}
 deps =
   {[testenv:functional]deps}
 commands =
-  {toxinidir}/tools/deploy_rootwrap.sh {toxinidir} {envdir}/etc {envdir}/bin
+  bash {toxinidir}/tools/deploy_rootwrap.sh {toxinidir} {envdir}/etc {envdir}/bin
   stestr run --exclude-regex (.*MySQL\.|.*PostgreSQL\.) {posargs}
   stestr run --combine --concurrency 1 (.*MySQL\.|.*PostgreSQL\.) {posargs}
 
@@ -80,16 +88,16 @@ setenv = {[testenv]setenv}
 deps =
   {[testenv:functional]deps}
 commands =
-  {toxinidir}/tools/generate_dhclient_script_for_fullstack.sh {envdir}
-  {toxinidir}/tools/deploy_rootwrap.sh {toxinidir} {envdir}/etc {envdir}/bin
+  bash {toxinidir}/tools/generate_dhclient_script_for_fullstack.sh {envdir}
+  bash {toxinidir}/tools/deploy_rootwrap.sh {toxinidir} {envdir}/etc {envdir}/bin
   stestr run --concurrency 2 {posargs}
 
 [testenv:dsvm-fullstack-gate]
 setenv = {[testenv:dsvm-fullstack]setenv}
 deps = {[testenv:dsvm-fullstack]deps}
 commands =
-  {toxinidir}/tools/generate_dhclient_script_for_fullstack.sh {envdir}
-  {toxinidir}/tools/deploy_rootwrap.sh {toxinidir} {envdir}/etc {envdir}/bin
+  bash {toxinidir}/tools/generate_dhclient_script_for_fullstack.sh {envdir}
+  bash {toxinidir}/tools/deploy_rootwrap.sh {toxinidir} {envdir}/etc {envdir}/bin
   stestr run --concurrency 2 --exclude-regex neutron.tests.fullstack.test_securitygroup.TestSecurityGroupsSameNetwork.test_securitygroup {posargs}
   stestr run --combine --concurrency 1 neutron.tests.fullstack.test_securitygroup.TestSecurityGroupsSameNetwork.test_securitygroup {posargs}
 
@@ -108,20 +116,18 @@ deps =
   pylint==2.5.3 # GPLv2
 commands=
   # If it is easier to add a check via a shell script, consider adding it in this file
-  sh ./tools/misc-sanity-checks.sh
-  {toxinidir}/tools/check_unit_test_structure.sh
+  bash ./tools/misc-sanity-checks.sh
+  bash {toxinidir}/tools/check_unit_test_structure.sh
   # Checks for coding and style guidelines
   flake8
-  sh ./tools/coding-checks.sh --pylint '{posargs}'
+  bash ./tools/coding-checks.sh --pylint '{posargs}'
   neutron-db-manage --config-file neutron/tests/etc/neutron.conf check_migration
   python ./tools/list_moved_globals.py
   {[testenv:genconfig]commands}
   {[testenv:bashate]commands}
   {[testenv:bandit]commands}
   {[testenv:genpolicy]commands}
-allowlist_externals =
-  sh
-  bash
+allowlist_externals = bash
 
 [testenv:cover]
 envdir = {toxworkdir}/shared
@@ -238,7 +244,7 @@ commands = bash -c "find {toxinidir}             \
 
 [testenv:genconfig]
 envdir = {toxworkdir}/shared
-commands = {toxinidir}/tools/generate_config_file_samples.sh
+commands = bash {toxinidir}/tools/generate_config_file_samples.sh
 
 [testenv:genpolicy]
 envdir = {toxworkdir}/shared
@@ -257,6 +263,6 @@ commands = bindep test
 [testenv:requirements]
 deps =
   -egit+https://opendev.org/openstack/requirements#egg=openstack-requirements
-allowlist_externals = sh
+allowlist_externals = bash
 commands =
-    sh -c '{envdir}/src/openstack-requirements/playbooks/files/project-requirements-change.py --req {envdir}/src/openstack-requirements --local {toxinidir} master'
+    bash -c '{envdir}/src/openstack-requirements/playbooks/files/project-requirements-change.py --req {envdir}/src/openstack-requirements --local {toxinidir} master'

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ passenv = TRACE_FAILONLY
           TOX_ENV_SRC_MODULES
 usedevelop = True
 deps =
-  -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/yoga}
+  -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/sapcc/requirements/stable/yoga-m3/upper-constraints.txt}
   -r{toxinidir}/requirements.txt
   -r{toxinidir}/test-requirements.txt
   hacking>=3.0.1,<3.1.0 # Apache-2.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist = docs,py38,pep8
 minversion = 3.18.0
-skipsdist = True
 ignore_basepython_conflict = True
 
 [testenv]


### PR DESCRIPTION
We need this, because tox4 behaves differently than 3 and our pull-requests CI's image uses tox4 already.

Please also see the individual commits' message.