### PR TITLE
  Reverting - Use explicit select condition in SQL query in "_port_filter_hook"

### DIFF
--- a/neutron/db/db_base_plugin_v2.py
+++ b/neutron/db/db_base_plugin_v2.py
@@ -43,7 +43,6 @@ from oslo_db import exception as os_db_exc
 from oslo_log import log as logging
 from oslo_utils import excutils
 from oslo_utils import uuidutils
-from sqlalchemy import and_
 from sqlalchemy import exc as sql_exc
 from sqlalchemy import func
 from sqlalchemy import not_
@@ -113,9 +112,10 @@ def _update_subnetpool_dict(orig_pool, new_pool):
 def _port_filter_hook(context, original_model, conditions):
     # Apply the port filter only in non-admin and non-advsvc context
     if ndb_utils.model_query_scope_is_project(context, original_model):
-        conditions |= and_(
-            models_v2.Port.network_id == models_v2.Network.id,
-            models_v2.Network.project_id == context.project_id)
+        conditions |= (models_v2.Port.network_id.in_(
+            context.session.query(models_v2.Network.id).
+            filter(context.project_id == models_v2.Network.project_id).
+            subquery()))
     return conditions
 
 
@@ -1600,7 +1600,6 @@ class NeutronDbPluginV2(db_base_plugin_common.DbBasePluginCommon,
             query = query.filter(IPAllocation.subnet_id.in_(subnet_ids))
         if limit:
             query = query.limit(limit)
-        query = query.distinct()
         return query
 
     @db_api.retry_if_session_inactive()


### PR DESCRIPTION
 Upgrading from neutron ussuri to yoga, some database performance issues have been observed, resulting in more CPU time required by the db.The most executed query (port list) introduced a select distinct, resulting in the increase in used CPU time. Details about the patch [explicit select condition in sql query](https://opendev.org/openstack/neutron/commit/923284fc3791949d93d7ded9820a44f98fc734b8)

