### PR TITLE
Parsable logging for metadata service requests

### DIFF
--- a/neutron/agent/metadata/agent.py
+++ b/neutron/agent/metadata/agent.py
@@ -259,6 +259,27 @@ class MetadataProxyHandler(object):
                                 cert=client_cert,
                                 verify=verify_cert)
 
+        # Log the proxied request + result in a parsable way
+        LOG.info('Metadata request - method: %(method)s path: "%(path)s" '
+                 'status: %(status)s client-ip: %(client_ip)s '
+                 'project-id: %(project_id)s os-network-id: %(os_network_id)s '
+                 'os-router-id: %(os_router_id)s '
+                 'os-instance-id: %(os_instance_id)s '
+                 'req-duration: %(req_duration)s '
+                 'user-agent: "%(user_agent)s"',
+            {
+                'method': req.method,
+                'path': req.url[len(req.host_url):],
+                'status': resp.status_code,
+                'client_ip': headers['X-Forwarded-For'],
+                'project_id': tenant_id,
+                'os_network_id': req.headers.get('X-Neutron-Network-ID'),
+                'os_router_id': req.headers.get('X-Neutron-Router-ID'),
+                'os_instance_id': instance_id,
+                'req_duration': resp.elapsed.total_seconds(),
+                'user_agent': req.headers.get('User-Agent'),
+            })
+
         if resp.status_code == 200:
             req.response.content_type = resp.headers['content-type']
             req.response.body = resp.content

--- a/neutron/tests/unit/agent/metadata/test_agent.py
+++ b/neutron/tests/unit/agent/metadata/test_agent.py
@@ -411,7 +411,9 @@ class _TestMetadataProxyHandlerCacheMixin(object):
         body = 'body'
 
         req = mock.Mock(path_info='/the_path', query_string='', headers=hdrs,
-                        method=method, body=body)
+                        method=method, body=body,
+                        url='https://example.com/my/request',
+                        host_url='https://example.com')
         resp = mock.MagicMock(status_code=response_code)
         resp.status.__str__.side_effect = AttributeError
         resp.content = 'content'


### PR DESCRIPTION
We want to get a better impression of what our users do with our metadata service and for this we want to improve the logging. The current logging logs part of the request (part by eventlet.wsgi, part by Neutron itself) or the complete ports request ("which ports do belong to the requester) as a multiline string representation of the request object.

To make debugging this easier for us we now log an extra single line for each request, containing many informations, as the current OpenStack network, client ip, user-agent, request path etc., which can then be easily consumed by some log parser (fluentd + grok in our case).