### PR TITLE
Remove X-Forwarded-For header in metadata haproxy

### DIFF
--- a/neutron/agent/metadata/driver.py
+++ b/neutron/agent/metadata/driver.py
@@ -73,6 +73,7 @@ listen listener
     bind %(host)s:%(port)s
     %(bind_v6_line)s
     server metadata %(unix_socket_path)s
+    http-request del-header X-Forwarded-For
     http-request del-header X-Neutron-%(res_type_del)s-ID
     http-request set-header X-Neutron-%(res_type)s-ID %(res_id)s
 """


### PR DESCRIPTION
When the user of our metadata service provides an X-Forwarded-For header in the request it will be forwarded to the neutron metadata service by haproxy, alongside with haproxy's own X-Forwarded-For header. On Neutron side this is then processed by eventlet.wsgi, which merges all values of headers that appear multiple times (separated by ','). The result of the merged addresses is then used by neutron in
_get_instance_and_tenant_id(), where it is converted to an netaddr.IPAddress. As this is not a valid value, the AddrFormatError exception is raised.

We do not want this exception to be raised, but even before that we don't want the user of a metadata service to be able to manipulate the X-Forwarded-For header in any way. Therefore we are now deleting this header in the haproxy frontend.