### PR TITLE
Don't break metadata with missing content-type

### DIFF
--- a/neutron/agent/metadata/agent.py
+++ b/neutron/agent/metadata/agent.py
@@ -281,7 +281,7 @@ class MetadataProxyHandler(object):
             })
 
         if resp.status_code == 200:
-            req.response.content_type = resp.headers['content-type']
+            req.response.content_type = resp.headers.get('content-type')
             req.response.body = resp.content
             LOG.debug(str(resp))
             return req.response


### PR DESCRIPTION
When sending an OPTIONS request to the metadata agent this request gets proxied to Nova, which then returns an empty HTTP response with content-length: 0 and no content-type key. This results in a KeyError, when we try to access this attribute. Using get() solves this and results in sending no content-type header to the client who requested this.

In our environment this can be reproduced with:
curl http://169.254.169.254/lol -X OPTION