### PR TITLE
Prefer default gw with ip on port on DHCP Agent

### DIFF
--- a/neutron/agent/linux/dhcp.py
+++ b/neutron/agent/linux/dhcp.py
@@ -1444,7 +1444,19 @@ class DeviceManager(object):
         if gateway:
             gateway = gateway.get('gateway')
 
+        # sort subnets by if they have their gateway ip present on a port
+        # and then by subnet created time
+        subnets_extended = []
         for subnet in network.subnets:
+            gw_ip_on_port = False
+            if subnet.gateway_ip:
+                gw_ip_on_port = any(fixed_ip.ip_address == subnet.gateway_ip
+                                    for port in network.ports
+                                    for fixed_ip in port.fixed_ips)
+            subnets_extended.append((subnet, gw_ip_on_port))
+        subnets_extended.sort(key=lambda sn: (not sn[1], sn[0].created_at))
+
+        for subnet, gw_ip_on_port in subnets_extended:
             skip_subnet = (
                 subnet.ip_version != ip_version or
                 not subnet.enable_dhcp or
@@ -1472,6 +1484,12 @@ class DeviceManager(object):
                           'on net %(n)s to %(ip)s',
                           {'n': network.id, 'ip': subnet.gateway_ip,
                            'version': ip_version})
+                if not gw_ip_on_port:
+                    LOG.warning('No port with gateway ip found for '
+                                'IPv%(version)s gateway on '
+                                'net %(n)s for %(ip)s',
+                                {'n': network.id, 'ip': subnet.gateway_ip,
+                                 'version': ip_version})
 
                 # Check for and remove the on-link route for the old
                 # gateway being replaced, if it is outside the subnet

--- a/neutron/tests/unit/agent/dhcp/test_agent.py
+++ b/neutron/tests/unit/agent/dhcp/test_agent.py
@@ -68,7 +68,8 @@ fake_subnet1 = dhcp.DictModel(id='bbbbbbbb-bbbb-bbbb-bbbbbbbbbbbb',
                               ip_version=const.IP_VERSION_4,
                               subnetpool_id=FAKE_V4_SUBNETPOOL_ID,
                               ipv6_ra_mode=None, ipv6_address_mode=None,
-                              allocation_pools=fake_subnet1_allocation_pools)
+                              allocation_pools=fake_subnet1_allocation_pools,
+                              created_at='2023-10-30T15:21:46Z')
 
 fake_subnet2_allocation_pools = dhcp.DictModel(id='', start='172.9.8.2',
                                                end='172.9.8.254')
@@ -79,7 +80,8 @@ fake_subnet2 = dhcp.DictModel(id='dddddddd-dddd-dddd-dddddddddddd',
                               gateway_ip='172.9.8.1',
                               host_routes=[], dns_nameservers=[],
                               ip_version=const.IP_VERSION_4,
-                              allocation_pools=fake_subnet2_allocation_pools)
+                              allocation_pools=fake_subnet2_allocation_pools,
+                              created_at='2023-10-30T15:21:46Z')
 
 fake_subnet3 = dhcp.DictModel(id='bbbbbbbb-1111-2222-bbbbbbbbbbbb',
                               network_id=FAKE_NETWORK_UUID,
@@ -1789,11 +1791,13 @@ class TestNetworkCache(base.BaseTestCase):
 class FakePort1(object):
     def __init__(self):
         self.id = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'
+        self.fixed_ips = []
 
 
 class FakePort2(object):
     def __init__(self):
         self.id = 'ffffffff-ffff-ffff-ffff-ffffffffffff'
+        self.fixed_ips = []
 
 
 class FakeV4Subnet(object):
@@ -1804,6 +1808,7 @@ class FakeV4Subnet(object):
         self.gateway_ip = '192.168.0.1'
         self.enable_dhcp = True
         self.subnetpool_id = FAKE_V4_SUBNETPOOL_ID
+        self.created_at = "2023-10-30T15:21:46Z"
 
 
 class FakeV6Subnet(object):
@@ -1814,12 +1819,14 @@ class FakeV6Subnet(object):
         self.gateway_ip = '2001:db8:0:1::1'
         self.enable_dhcp = True
         self.subnetpool_id = FAKE_V6_SUBNETPOOL_ID
+        self.created_at = "2023-10-30T15:21:46Z"
 
 
 class FakeV4SubnetOutsideGateway(FakeV4Subnet):
     def __init__(self):
         super(FakeV4SubnetOutsideGateway, self).__init__()
         self.gateway_ip = '192.168.1.1'
+        self.created_at = "2023-10-30T15:21:46Z"
 
 
 class FakeV6SubnetOutsideGateway(FakeV6Subnet):
@@ -1835,6 +1842,7 @@ class FakeV4SubnetNoGateway(object):
         self.cidr = '192.168.1.0/24'
         self.gateway_ip = None
         self.enable_dhcp = True
+        self.created_at = "2023-10-30T15:21:46Z"
 
 
 class FakeV6SubnetNoGateway(object):
@@ -1844,6 +1852,7 @@ class FakeV6SubnetNoGateway(object):
         self.cidr = '2001:db8:1:0::/64'
         self.gateway_ip = None
         self.enable_dhcp = True
+        self.created_at = "2023-10-30T15:21:46Z"
 
 
 class FakeV4Network(object):

--- a/neutron/tests/unit/agent/linux/test_dhcp.py
+++ b/neutron/tests/unit/agent/linux/test_dhcp.py
@@ -440,6 +440,7 @@ class FakeV4Subnet(Dictable):
         self.host_routes = [FakeV4HostRoute()]
         self.dns_nameservers = ['8.8.8.8']
         self.subnetpool_id = 'kkkkkkkk-kkkk-kkkk-kkkk-kkkkkkkkkkkk'
+        self.created_at = "2023-10-27T05:21:46Z"
 
 
 class FakeV4Subnet2(FakeV4Subnet):
@@ -449,6 +450,7 @@ class FakeV4Subnet2(FakeV4Subnet):
         self.cidr = '192.168.1.0/24'
         self.gateway_ip = '192.168.1.1'
         self.host_routes = []
+        self.created_at = "2023-10-20T05:21:46Z"
 
 
 class FakeV4SubnetSegmentID(FakeV4Subnet):
@@ -579,6 +581,7 @@ class FakeV4SubnetNoDHCP(object):
         self.enable_dhcp = False
         self.host_routes = []
         self.dns_nameservers = []
+        self.created_at = "2023-10-26T05:21:46Z"
 
 
 class FakeV6SubnetDHCPStateful(Dictable):
@@ -593,6 +596,7 @@ class FakeV6SubnetDHCPStateful(Dictable):
         self.ipv6_ra_mode = None
         self.ipv6_address_mode = constants.DHCPV6_STATEFUL
         self.subnetpool_id = 'mmmmmmmm-mmmm-mmmm-mmmm-mmmmmmmmmmmm'
+        self.created_at = "2023-10-25T05:21:46Z"
 
 
 class FakeV6SubnetSlaac(object):
@@ -786,6 +790,14 @@ class FakeDualNetworkDualDHCP(object):
         self.id = 'cccccccc-cccc-cccc-cccc-cccccccccccc'
         self.subnets = [FakeV4Subnet(), FakeV4Subnet2()]
         self.ports = [FakePort1(), FakeRouterPort(), FakeRouterPort2()]
+        self.namespace = 'qdhcp-ns'
+
+
+class FakeDualNetworkDualDHCPOneRouter(object):
+    def __init__(self):
+        self.id = 'cccccccc-cccc-cccc-cccc-cccccccccccc'
+        self.subnets = [FakeV4Subnet(), FakeV4Subnet2()]
+        self.ports = [FakePort1(), FakeRouterPort2()]
         self.namespace = 'qdhcp-ns'
 
 
@@ -3383,6 +3395,17 @@ class TestDeviceManager(TestConfBase):
 
         with testtools.ExpectedException(oslo_messaging.RemoteError):
             dh.setup_dhcp_port(fake_network)
+
+    def test_prefer_subnet_with_gateway_ip_on_port_as_default_gateway(self):
+        with mock.patch.object(dhcp.ip_lib, 'IPDevice') as mock_IPDevice:
+            device = mock.Mock()
+            mock_IPDevice.return_value = device
+            device.route.get_gateway.return_value = None
+            plugin = mock.Mock()
+            mgr = dhcp.DeviceManager(self.conf, plugin)
+            network = FakeDualNetworkDualDHCPOneRouter()
+            mgr._set_default_route(network, "LOL")
+            device.route.add_gateway.assert_called_with("192.168.1.1")
 
 
 class TestDictModel(base.BaseTestCase):


### PR DESCRIPTION
When multiple subnets are configured in the same network, the DHCP agent will choose the first suitable subnet with a gateway ip set as default gateway, where the subnets are in a generally stable, but arbitrary order. In some cases only some of the subnets in a network actually have a router in it, meaning a DHCP agent might loose Internet access (used for example for DNS).

Now we sort the subnets before selecting a default gateway. Subnets are sorted first by if their gateway ip is present on a port in the network and then by their created_at time, so we always have a stable order. Also, using the first created subnet seems like a good decision, as it will probably be the one with the least fluctuations. We won't filter for a router port, as the user could also provide a custom router via a VM in their network. In case no subnet is present on a port we will still use one of them as default route, just to preserve the old behavior.