### PR TITLE
Introducing the edns_client_fingerprint option

### DIFF
--- a/neutron/agent/linux/dhcp.py
+++ b/neutron/agent/linux/dhcp.py
@@ -41,6 +41,7 @@ from neutron.agent.linux import external_process
 from neutron.agent.linux import ip_lib
 from neutron.agent.linux import iptables_manager
 from neutron.cmd import runtime_checks as checks
+from neutron.cmd.sanity import checks as sanity_checks
 from neutron.common import utils as common_utils
 from neutron.ipam import utils as ipam_utils
 from neutron.privileged.agent.linux import dhcp as priv_dhcp
@@ -391,6 +392,7 @@ class Dnsmasq(DhcpLocalProcess):
 
     _IS_DHCP_RELEASE6_SUPPORTED = None
     _IS_HOST_TAG_SUPPORTED = None
+    _IS_UMBRELLA_SUPPORTED = None
 
     @classmethod
     def check_version(cls):
@@ -520,6 +522,12 @@ class Dnsmasq(DhcpLocalProcess):
                 cmd.append('--log-dhcp')
                 cmd.append('--log-facility=%s' % log_filename)
 
+        # fingerprint the client (network id + client IP)
+        if self.conf.edns_client_fingerprint:
+            cmd.append('--add-cpe-id=%s' % self.network.id)
+            if self._is_dnsmasq_umbrella_supported():
+                cmd.append('--umbrella')
+
         return cmd
 
     def spawn_process(self):
@@ -561,6 +569,13 @@ class Dnsmasq(DhcpLocalProcess):
             self._IS_HOST_TAG_SUPPORTED = checks.dnsmasq_host_tag_support()
 
         return self._IS_HOST_TAG_SUPPORTED
+
+    def _is_dnsmasq_umbrella_supported(self):
+        if self._IS_UMBRELLA_SUPPORTED is None:
+            self._IS_UMBRELLA_SUPPORTED = (
+                sanity_checks.dnsmasq_umbrella_supported())
+
+        return self._IS_UMBRELLA_SUPPORTED
 
     def _release_lease(self, mac_address, ip, ip_version, client_id=None,
                        server_id=None, iaid=None):

--- a/neutron/cmd/sanity/checks.py
+++ b/neutron/cmd/sanity/checks.py
@@ -47,6 +47,7 @@ LOG = logging.getLogger(__name__)
 MINIMUM_DNSMASQ_VERSION = '2.67'
 DNSMASQ_VERSION_DHCP_RELEASE6 = '2.76'
 DNSMASQ_VERSION_HOST_ADDR6_LIST = '2.81'
+DNSMASQ_VERSION_UMBRELLA = '2.86'
 DIRECT_PORT_QOS_MIN_OVS_VERSION = '2.11'
 MINIMUM_DIBBLER_VERSION = '1.0.1'
 CONNTRACK_GRE_MODULE = 'nf_conntrack_proto_gre'
@@ -219,6 +220,10 @@ def get_dnsmasq_version_with_host_addr6_list():
     return DNSMASQ_VERSION_HOST_ADDR6_LIST
 
 
+def get_dnsmasq_version_with_umbrella():
+    return DNSMASQ_VERSION_UMBRELLA
+
+
 def get_ovs_version_for_qos_direct_port_support():
     return DIRECT_PORT_QOS_MIN_OVS_VERSION
 
@@ -288,6 +293,31 @@ def ovs_qos_direct_port_supported():
 
 def dhcp_release6_supported():
     return priv_dhcp.dhcp_release6_supported()
+
+
+def dnsmasq_umbrella_supported():
+    try:
+        cmd = ['dnsmasq', '--version']
+        env = {'LC_ALL': 'C'}
+        out = agent_utils.execute(cmd, addl_env=env)
+        m = re.search(r"version (\d+\.\d+)", out)
+        ver = distutils.version.StrictVersion(m.group(1) if m else '0.0')
+        if ver >= distutils.version.StrictVersion(DNSMASQ_VERSION_UMBRELLA):
+            return True
+
+        LOG.warning('Support for the `--umbrella` dnsmasq option '
+                    'was introduced in dnsmasq version '
+                    '%(required)s. Found dnsmasq version %(current)s. '
+                    'DNS client fingerprinting will not include client IPs.',
+                    {'required': DNSMASQ_VERSION_UMBRELLA,
+                     'current': ver})
+    except (OSError, RuntimeError, IndexError, ValueError) as e:
+        LOG.debug("Exception while checking dnsmasq for `--umbrella` option "
+                  " support. "
+                  "Exception: %s", e)
+
+    # unsupported unless explicitly stated otherwise
+    return False
 
 
 def bridge_firewalling_enabled():

--- a/neutron/cmd/sanity_check.py
+++ b/neutron/cmd/sanity_check.py
@@ -275,6 +275,17 @@ def check_dhcp_release6():
     return result
 
 
+def check_dnsmasq_umbrella_supported():
+    result = checks.dnsmasq_umbrella_supported()
+    if not result:
+        LOG.warning('The installed version of dnsmasq does not support '
+                    'the `--umbrella` option. '
+                    'Please update to at least version %s if you need '
+                    'full DNS client fingerprinting.',
+                  checks.get_dnsmasq_version_with_umbrella())
+    return result
+
+
 def check_bridge_firewalling_enabled():
     result = checks.bridge_firewalling_enabled()
     if not result:
@@ -380,6 +391,9 @@ OPTS = [
                     help=_('Check conntrack installation')),
     BoolOptCallback('dhcp_release6', check_dhcp_release6,
                     help=_('Check dhcp_release6 installation')),
+    BoolOptCallback('dnsmasq_umbrella_supported',
+                    check_dnsmasq_umbrella_supported,
+                    help=_('Check dnsmasq support for `--umbrella` option')),
     BoolOptCallback('bridge_firewalling', check_bridge_firewalling_enabled,
                     help=_('Check bridge firewalling'),
                     default=False),
@@ -431,6 +445,7 @@ def enable_tests_from_config():
     if cfg.CONF.dhcp_driver == 'neutron.agent.linux.dhcp.Dnsmasq':
         cfg.CONF.set_default('dnsmasq_local_service_supported', True)
         cfg.CONF.set_default('dnsmasq_version', True)
+        cfg.CONF.set_default('dnsmasq_umbrella_supported', True)
     if cfg.CONF.l3_ha:
         cfg.CONF.set_default('keepalived_ipv6_support', True)
         cfg.CONF.set_default('ip_nonlocal_bind', True)

--- a/neutron/conf/agent/dhcp.py
+++ b/neutron/conf/agent/dhcp.py
@@ -113,7 +113,11 @@ DNSMASQ_OPTS = [
                 help=_("Use broadcast in DHCP replies.")),
     cfg.BoolOpt('dnsmasq_enable_addr6_list', default=False,
                 help=_("Enable dhcp-host entry with list of addresses when "
-                       "port has multiple IPv6 addresses in the same subnet."))
+                       "port has multiple IPv6 addresses in the same "
+                       "subnet.")),
+    cfg.BoolOpt('edns_client_fingerprint', default=False,
+                help=_("Add the network id and client IP as an eDNS payload "
+                       "to each client DNS query sent to the DNS resolvers")),
 ]
 
 

--- a/neutron/tests/unit/agent/linux/test_dhcp.py
+++ b/neutron/tests/unit/agent/linux/test_dhcp.py
@@ -33,6 +33,7 @@ import testtools
 from neutron.agent.linux import dhcp
 from neutron.agent.linux import ip_lib
 from neutron.cmd import runtime_checks as checks
+from neutron.cmd.sanity import checks as sanity_checks
 from neutron.common import utils as common_utils
 from neutron.conf.agent import common as config
 from neutron.conf.agent import dhcp as dhcp_config
@@ -1530,6 +1531,46 @@ class TestDnsmasq(TestBase):
                           '--server=8.8.8.8',
                           '--server=9.9.9.9',
                           '--domain=openstacklocal'])
+
+    def test_dnsmasq_umbrella_support_check(self):
+        with mock.patch('neutron.agent.linux.utils.execute') \
+                        as dnsmasq_version_mock:
+
+            # no umbrella support in 2.85 and below
+            dnsmasq_version_mock.return_value = "version 2.85"
+            self.assertFalse(sanity_checks.dnsmasq_umbrella_supported())
+
+            # umbrella support introduced in 2.86
+            dnsmasq_version_mock.return_value = "version 2.86"
+            self.assertTrue(sanity_checks.dnsmasq_umbrella_supported())
+
+    def test_spawn_cfg_edns_client_fingerprint_disabled(self):
+        self.conf.set_override('edns_client_fingerprint', False)
+        self._test_spawn(['--conf-file=',
+                          '--domain=openstacklocal'])
+
+    @mock.patch.object(sanity_checks,
+                       'dnsmasq_umbrella_supported', return_value=True)
+    def test_spawn_cfg_edns_client_fingerprint_with_umbrella(self,
+            mock_umbrella_supported):
+        self.conf.set_override('edns_client_fingerprint', True)
+        network = FakeDualNetwork()
+        self._test_spawn(['--conf-file=',
+                          '--domain=openstacklocal',
+                          '--add-cpe-id=%s' % network.id,
+                          '--umbrella'],
+                         network=network)
+
+    @mock.patch.object(sanity_checks,
+                       'dnsmasq_umbrella_supported', return_value=False)
+    def test_spawn_cfg_edns_client_fingerprint_without_umbrella(self,
+            mock_umbrella_supported):
+        self.conf.set_override('edns_client_fingerprint', True)
+        network = FakeDualNetwork()
+        self._test_spawn(['--conf-file=',
+                          '--domain=openstacklocal',
+                          '--add-cpe-id=%s' % network.id],
+                         network=network)
 
     def test_spawn_cfg_enable_dnsmasq_log(self):
         self.conf.set_override('dnsmasq_base_log_dir', '/tmp')


### PR DESCRIPTION
### Motivation and goals
The motivation is to assist the upstream DNS resolvers in identifying the clients using the neutron dnsmasq resolvers.
The actual goal is monitoring of the DNS traffic for suspicious activity and uncovering compromised systems.

### Implementation
This is done by passing each client's IP address and network id to the upstream resolvers by adding that information as eDNS payload to the DNS query going out.

If this boolean option is toggled then the following two command line options will be appended to dnsmasq:
`--add-cpe-id=<network_id>`
`--umbrella`

The former will add the network id to eDNS option 65074.
The latter will add the client IP to eDNS option 20292.

### Caveat
The `--umbrella` option was introduced in dnsmasq 2.86.
A dnsmasq version check is in place to make sure the option does not get activated if the currently installed version is older than that.
In this case a warning will be logged and the fingerprinting will be reduced to the network id only.