### PR TITLE
Don't delete already deleted extra router routes

### DIFF
--- a/neutron/db/extraroute_db.py
+++ b/neutron/db/extraroute_db.py
@@ -133,11 +133,11 @@ class ExtraRoute_dbonly_mixin(l3_db.L3_NAT_dbonly_mixin):
 
         LOG.debug('Removed routes are %s', removed)
         for route in removed:
-            l3_obj.RouterRoute.get_object(
+            l3_obj.RouterRoute.delete_objects(
                 context,
                 router_id=router['id'],
                 destination=route['destination'],
-                nexthop=route['nexthop']).delete()
+                nexthop=route['nexthop'])
         return added, removed
 
     @staticmethod


### PR DESCRIPTION
When handling the deletion of extra routes we need to handle the case that the route is already deleted by another call in the time we have fetched the extra routes and try to delete it. This is a classic race condition when two calls try to update the routes of a router at the same time.