### PR TITLE
Support on DHCP-agent for internal v6 networks

### DIFF
--- a/neutron/agent/linux/dhcp.py
+++ b/neutron/agent/linux/dhcp.py
@@ -436,6 +436,7 @@ class Dnsmasq(DhcpLocalProcess):
             ]
 
         possible_leases = 0
+        enable_ra = False
         for subnet in self._get_all_subnets(self.network):
             mode = None
             # if a subnet is specified to have dhcp disabled
@@ -452,6 +453,9 @@ class Dnsmasq(DhcpLocalProcess):
                                   constants.DHCPV6_STATELESS] or
                         not addr_mode and not ra_mode):
                     mode = 'static'
+                if addr_mode == constants.DHCPV6_STATEFUL and \
+                        ra_mode in (constants.DHCPV6_STATEFUL, None):
+                    enable_ra = True
 
             cidr = netaddr.IPNetwork(subnet.cidr)
 
@@ -487,6 +491,12 @@ class Dnsmasq(DhcpLocalProcess):
         # this possible lease cap.
         cmd.append('--dhcp-lease-max=%d' %
                    min(possible_leases, self.conf.dnsmasq_lease_max))
+
+        if self.conf.enable_router_advertisements and enable_ra:
+            LOG.debug("Enabling ra in dnsmasq for network %s", self.network.id)
+            cmd.append('--enable-ra')
+            iface_name = self.interface_name or '*'
+            cmd.append(f'--ra-param={iface_name},0,0')
 
         if self.conf.dhcp_renewal_time > 0:
             cmd.append('--dhcp-option-force=option:T1,%ds' %

--- a/neutron/conf/agent/dhcp.py
+++ b/neutron/conf/agent/dhcp.py
@@ -118,6 +118,11 @@ DNSMASQ_OPTS = [
     cfg.BoolOpt('edns_client_fingerprint', default=False,
                 help=_("Add the network id and client IP as an eDNS payload "
                        "to each client DNS query sent to the DNS resolvers")),
+    cfg.BoolOpt('enable_router_advertisements', default=False,
+                help=_("Enable IPv6 router advertisements from dnsmasq. "
+                       "This only supplements DHCPv6 by announcing the "
+                       "network's prefix length and does not announce "
+                       "a default gateway.")),
 ]
 
 

--- a/neutron/tests/unit/agent/linux/test_dhcp.py
+++ b/neutron/tests/unit/agent/linux/test_dhcp.py
@@ -1628,6 +1628,16 @@ class TestDnsmasq(TestBase):
         self._test_spawn(['--conf-file=', '--domain=openstacklocal'],
                          dhcp_t1=30, dhcp_t2=100)
 
+    def test_spawn_cfg_with_stateful_dhcpv6_and_ra_enabled(self):
+        self.conf.set_override('enable_router_advertisements', True)
+        network = FakeV6NetworkStatefulDHCPSameSubnetFixedIps()
+
+        self._test_spawn(['--enable-ra',
+                          '--ra-param=tap0,0,0',
+                          '--conf-file=',
+                          '--domain=openstacklocal',
+                          ], network)
+
     def _test_output_init_lease_file(self, timestamp):
         expected = [
             '00:00:80:aa:bb:cc 192.168.0.2 * *',


### PR DESCRIPTION
When we have a network with stateful DHCPv6 we still need router advertisements to tell the hosts the prefix length of the current network (else all hosts will just have /128 routes). In cases where a network does not have a router (or don't use an l3 plugin with ra support) we do not have something in the network that sends out ras (radvd itself is launched on the l3 agent with Neutron's default implementation).

Therefore we now let dnsmasq take over this task. With --enable-ra we enable dnsmasq's ra implementation. We use --ra-param=$iface,0,0 to deactivate that dnsmasq is advertising itself as default gateway. Params are (interface, use default ra-interval, router lifetime).