### PR TITLE
Switch to our own oslo.log

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ oslo.config>=8.0.0 # Apache-2.0
 oslo.context>=2.22.0 # Apache-2.0
 oslo.db>=4.44.0 # Apache-2.0
 oslo.i18n>=3.20.0 # Apache-2.0
-oslo.log>=4.5.0 # Apache-2.0
+oslo.log @ git+https://github.com/sapcc/oslo.log@4.7.0
 oslo.messaging>=7.0.0 # Apache-2.0
 oslo.middleware>=3.31.0 # Apache-2.0
 oslo.policy>=3.10.1 # Apache-2.0


### PR DESCRIPTION
Our own oslo.log is based on 4.7.0 (latest oslo.logyoga release) with an
additional patch to prevent deadlocks when logging is used with native
and greenthreads ad the same time.

This is only needed for Neutron yoga and should be dropped on a later
version of Neutron. The version, even with containing some extra commits
is hard-set on 4.7.0 to work with the current upper-constraints.