### PR TITLE
Set branch for sappcc sentrylogger installation

### DIFF
--- a/custom-requirements.txt
+++ b/custom-requirements.txt
@@ -6,7 +6,7 @@ dumb-init
 
 # sentry client
 raven
-git+https://github.com/sapcc/sentrylogger.git#egg=sapcc_sentrylogger
+git+https://github.com/sapcc/sentrylogger.git@main#egg=sapcc_sentrylogger
 
 # agent checks for neutron
 openstack-agent-checks


### PR DESCRIPTION
Adding the sapcc_sentrylogger dependency without a branch name causes an issue once we update our CI pipeline. As no branch is specified master branch is assumed as default causing the pipeline to fail. Once we set the name our scripts updating the CI pipeline will pick up the branch name and do not assume a default anymore.