### PR TITLE
[OVN] Enable the WSGI module for the OVN mechanism driver

### DIFF
--- a/neutron/common/ovn/utils.py
+++ b/neutron/common/ovn/utils.py
@@ -573,10 +573,12 @@ def get_port_subnet_ids(port):
     return [f['subnet_id'] for f in fixed_ips]
 
 
-def get_method_class(method):
-    if not inspect.ismethod(method):
+def get_method_class(method_or_class):
+    if not inspect.ismethod(method_or_class):
+        if inspect.isclass(method_or_class):
+            return method_or_class
         return
-    return method.__self__.__class__
+    return method_or_class.__self__.__class__
 
 
 def ovn_metadata_name(id_):


### PR DESCRIPTION
This is a backport from Neutron dalmatian and is required for OVN running with neutron-api/neutron-rpc-server instead of combined neutron-server.

This patch enables the use of the WSGI module with the ML2/OVN
mechanism driver. The ML2/OVN requires two events that are called
during the Neutron eventlet server initialization:
* BEFORE_SPAWN: called once before the API workers have been created
  and after the ML2 plugin code has been initalizated.
* AFTER_INIT: called when the API worker is started; at this point
  the different worker processes have been spawned.

The WSGI module didn't make these event calls. Now these events are
called during the API server initialization, after the ML2 plugin
has been initalizated but before the server is running and attending
any request.

This approach differs from the Neutron eventlet server event calls
because the BEFORE_SPAWN event is called for all API workers; that
means the method ``OVNMechanismDriver.pre_fork_initialize`` is called
as many times as workers are configured.

Closes-Bug: #1912359
Change-Id: I684c6cea620308a6617b665400ce608650a2adfd
