### PR TITLE
customdns - fix keystone session, needed for caracal/sdk update

### DIFF
--- a/neutron/api/rpc/handlers/dhcp_rpc.py
+++ b/neutron/api/rpc/handlers/dhcp_rpc.py
@@ -118,10 +118,13 @@ class CustomNetworkConfigurator:
             keystone_session = ks_loading.load_session_from_conf_options(
                     cfg.CONF, auth_section, auth=auth)
             self._KEYSTONE = connection.Connection(
-                    session=keystone_session, oslo_conf=cfg.CONF,
-                    connect_retries=cfg.CONF.http_retries)
+                    session=keystone_session,
+                    connect_retries=cfg.CONF.http_retries,
+                    service_types={'identity'},
+                    strict_proxies=True,
+                    identity_interface='internal')
 
-        return self._KEYSTONE
+        return self._KEYSTONE.identity
 
     def get_domain_name(self, project_id: str) -> str:
         """query keystone to get the name of the domain that


### PR DESCRIPTION
After updating to Caracal and using openstacksdk 3.0.0 the sdk refused initializing the identity client correctly to talk to keystone.

This apparently happens when a full config is given to the Connection, and should not have worked before.

Also now calling identity directly without indirection, which also should be more efficient because it uses a direct get for the id.