### PR TITLE
ovn sci adaptions

### DIFF
--- a/neutron/cmd/ovn/neutron_ovn_db_sync_util.py
+++ b/neutron/cmd/ovn/neutron_ovn_db_sync_util.py
@@ -197,10 +197,12 @@ def main():
                       cfg.CONF.ml2.mechanism_drivers)
             return
         cfg.CONF.set_override('mechanism_drivers', ['ovn-sync'], 'ml2')
+        # SCI: we disable hardcoded OVN l3 plugins, so db-sync-util won't
+        # try to sync routers/router ports and assign them to ovn gateways.
         conf.service_plugins = [
-            'neutron.services.ovn_l3.plugin.OVNL3RouterPlugin',
+            # 'neutron.services.ovn_l3.plugin.OVNL3RouterPlugin',
             'neutron.services.segments.plugin.Plugin',
-            'port_forwarding',
+            # 'port_forwarding',
             'qos'
         ]
         extension_drivers = list(set(cfg.CONF.ml2.extension_drivers + ['qos']))

--- a/neutron/common/ovn/utils.py
+++ b/neutron/common/ovn/utils.py
@@ -347,7 +347,10 @@ def is_lsp_up(lsp):
 
 
 def is_snat_enabled(router):
-    return router.get(l3.EXTERNAL_GW_INFO, {}).get('enable_snat', True)
+    router = router.get(l3.EXTERNAL_GW_INFO, {})
+    if not router:
+        return True
+    return router.get('enable_snat', True)
 
 
 def is_port_security_enabled(port):

--- a/neutron/plugins/ml2/drivers/ovn/mech_driver/ovsdb/maintenance.py
+++ b/neutron/plugins/ml2/drivers/ovn/mech_driver/ovsdb/maintenance.py
@@ -694,6 +694,10 @@ class DBInconsistenciesPeriodics(SchemaAwarePeriodicsBase):
         """
         context = n_context.get_admin_context()
         cmds = []
+        if not utils.is_ovn_l3(self._ovn_client._l3_plugin):
+            LOG.debug("OVN L3 plugin is not enabled, skipping check for "
+                      "redirect-type on router gateway ports")
+            raise periodics.NeverAgain()
         gw_ports = self._ovn_client._plugin.get_ports(
             context, {'device_owner': [n_const.DEVICE_OWNER_ROUTER_GW]})
         for gw_port in gw_ports:
@@ -755,6 +759,10 @@ class DBInconsistenciesPeriodics(SchemaAwarePeriodicsBase):
         """
         context = n_context.get_admin_context()
         cmds = []
+        if not utils.is_ovn_l3(self._ovn_client._l3_plugin):
+            LOG.debug("OVN L3 plugin is not enabled, skipping check for "
+                      "redirect-type on router gateway ports")
+            raise periodics.NeverAgain()
         # Get router ports belonging to VLAN or FLAT networks
         vlan_nets = self._ovn_client._plugin.get_networks(
             context, {pnet.NETWORK_TYPE: [n_const.TYPE_VLAN,
@@ -990,10 +998,11 @@ class DBInconsistenciesPeriodics(SchemaAwarePeriodicsBase):
         """Add info if LRP is connecting internal subnet or ext gateway."""
         cmds = []
         context = n_context.get_admin_context()
+        if not utils.is_ovn_l3(self._ovn_client._l3_plugin):
+            LOG.debug("OVN L3 plugin is not enabled, skipping check for "
+                      "external gateway on router ports")
+            raise periodics.NeverAgain()
         for router in self._ovn_client._l3_plugin.get_routers(context):
-            if not router.get('external_gateways'):
-                # No external gateways - ovn l3 plugin is not used
-                raise periodics.NeverAgain()
             ext_gw_networks = [
                 ext_gw['network_id'] for ext_gw in router['external_gateways']]
             rtr_name = 'neutron-{}'.format(router['id'])

--- a/neutron/plugins/ml2/drivers/ovn/mech_driver/ovsdb/maintenance.py
+++ b/neutron/plugins/ml2/drivers/ovn/mech_driver/ovsdb/maintenance.py
@@ -898,7 +898,7 @@ class DBInconsistenciesPeriodics(SchemaAwarePeriodicsBase):
         with self._nb_idl.transaction(check_error=True) as txn:
             for port in ports:
                 lsp = self._nb_idl.lsp_get(port['id']).execute(
-                    check_error=True)
+                    log_errors=False)
                 if not lsp:
                     continue
 
@@ -991,6 +991,9 @@ class DBInconsistenciesPeriodics(SchemaAwarePeriodicsBase):
         cmds = []
         context = n_context.get_admin_context()
         for router in self._ovn_client._l3_plugin.get_routers(context):
+            if not router.get('external_gateways'):
+                # No external gateways - ovn l3 plugin is not used
+                raise periodics.NeverAgain()
             ext_gw_networks = [
                 ext_gw['network_id'] for ext_gw in router['external_gateways']]
             rtr_name = 'neutron-{}'.format(router['id'])

--- a/neutron/plugins/ml2/drivers/ovn/mech_driver/ovsdb/ovn_client.py
+++ b/neutron/plugins/ml2/drivers/ovn/mech_driver/ovsdb/ovn_client.py
@@ -2064,7 +2064,10 @@ class OVNClient(object):
                 ','.join(common_utils.get_az_hints(network)),
             # NOTE(ralonsoh): it is not considered the case of multiple
             # segments.
-            ovn_const.OVN_NETTYPE_EXT_ID_KEY: network.get(pnet.NETWORK_TYPE),
+            # SCI: hardcoding TYPE_VLAN for every network, thus enabling local
+            # gateway termination via VLAN tagging.
+            ovn_const.OVN_NETTYPE_EXT_ID_KEY: network.get(pnet.NETWORK_TYPE,
+                                                          const.TYPE_VLAN),
         }}
 
         # Enable IGMP snooping if igmp_snooping_enable is enabled in Neutron

--- a/neutron/plugins/ml2/drivers/ovn/mech_driver/ovsdb/ovn_client.py
+++ b/neutron/plugins/ml2/drivers/ovn/mech_driver/ovsdb/ovn_client.py
@@ -563,7 +563,7 @@ class OVNClient(object):
             ovn_const.OVN_SG_IDS_EXT_ID_KEY: port_info.security_group_ids,
             ovn_const.OVN_REV_NUM_EXT_ID_KEY: str(utils.get_revision_number(
                 port, ovn_const.TYPE_PORTS)),
-            ovn_const.OVN_PORT_VNIC_TYPE_KEY: port_info.vnic_type,
+            ovn_const.OVN_PORT_VNIC_TYPE_KEY: port_info.vnic_type or '',
             ovn_const.OVN_PORT_BP_CAPABILITIES_KEY:
                 ';'.join(port_info.capabilities),
             ovn_const.OVN_NETWORK_MTU_EXT_ID_KEY: port_info.mtu,

--- a/neutron/plugins/ml2/drivers/ovn/mech_driver/ovsdb/ovn_db_sync.py
+++ b/neutron/plugins/ml2/drivers/ovn/mech_driver/ovsdb/ovn_db_sync.py
@@ -1174,7 +1174,7 @@ class OvnNbSynchronizer(OvnDbSynchronizer):
                             "but not in Neutron network_id=%(net)s "
                             "port_name=%(lport)s",
                             {'net': network,
-                             'seg': lport})
+                             'lport': lport})
                 if self.mode == SYNC_MODE_REPAIR:
                     LOG.warning('Deleting provider network port %s from '
                                 'OVN NB DB', lport)

--- a/neutron/plugins/ml2/drivers/ovn/mech_driver/ovsdb/ovn_db_sync.py
+++ b/neutron/plugins/ml2/drivers/ovn/mech_driver/ovsdb/ovn_db_sync.py
@@ -76,10 +76,11 @@ class OvnNbSynchronizer(OvnDbSynchronizer):
         self.mode = mode
         self.l3_plugin = directory.get_plugin(plugin_constants.L3)
         self.pf_plugin = directory.get_plugin(plugin_constants.PORTFORWARDING)
-        if not self.pf_plugin:
-            self.pf_plugin = (
-                manager.NeutronManager.load_class_for_provider(
-                    'neutron.service_plugins', 'port_forwarding')())
+        # SCI: only needed for ovn l3 plugin
+        # if not self.pf_plugin:
+        #     self.pf_plugin = (
+        #         manager.NeutronManager.load_class_for_provider(
+        #             'neutron.service_plugins', 'port_forwarding')())
         self._ovn_client = ovn_client.OVNClient(ovn_api, sb_ovn)
         self.segments_plugin = directory.get_plugin('segments')
         if not self.segments_plugin:
@@ -1071,8 +1072,7 @@ class OvnNbSynchronizer(OvnDbSynchronizer):
                                                 'lswitch': lswitch['name']})
                 db_network = db_networks[lswitch['name']]
                 db_segments = self.segments_plugin.get_segments(
-                    ctx, filters={'network_id': [db_network['id']],
-                                  'is_dynamic': False})
+                    ctx, filters={'network_id': [db_network['id']]})
                 segments_provnet_port_names = []
                 for db_segment in db_segments:
                     physnet = db_segment.get(segment_def.PHYSICAL_NETWORK)
@@ -1269,6 +1269,11 @@ class OvnNbSynchronizer(OvnDbSynchronizer):
 
     def sync_fip_qos_policies(self, ctx):
         """Sync floating IP QoS policies."""
+        if not utils.is_ovn_l3(self.l3_plugin):
+            LOG.debug("OVN L3 mode is disabled, skipping "
+                      "floating IP QoS policies")
+            return
+
         LOG.debug('OVN-NB Sync Floating IP QoS policies started @ %s',
                   str(datetime.now()))
         ovn_qos_ext = ovn_qos.OVNClientQosExtension(nb_idl=self.ovn_api)

--- a/neutron/plugins/ml2/drivers/ovn/mech_driver/ovsdb/ovsdb_monitor.py
+++ b/neutron/plugins/ml2/drivers/ovn/mech_driver/ovsdb/ovsdb_monitor.py
@@ -474,8 +474,10 @@ class LogicalSwitchPortCreateEvent(row_event.RowEvent):
     def run(self, event, row, old):
         if utils.is_lsp_up(row) and utils.is_lsp_enabled(row):
             self.driver.set_port_status_up(row.name)
-        else:
-            self.driver.set_port_status_down(row.name)
+        # SCI: don't set explicit down status for ports that just got created
+        # because the port could be bound by another driver
+        # else:
+        #     self.driver.set_port_status_down(row.name)
 
 
 class LogicalSwitchPortUpdateUpEvent(row_event.RowEvent):

--- a/neutron/tests/unit/plugins/ml2/drivers/ovn/mech_driver/ovsdb/test_ovn_db_sync.py
+++ b/neutron/tests/unit/plugins/ml2/drivers/ovn/mech_driver/ovsdb/test_ovn_db_sync.py
@@ -388,6 +388,13 @@ class TestOvnNbSyncML2(test_mech_driver.OVNMechanismDriverTestCase):
         ovn_driver = ovn_nb_synchronizer.ovn_driver
         l3_plugin = ovn_nb_synchronizer.l3_plugin
         pf_plugin = ovn_nb_synchronizer.pf_plugin
+        if not pf_plugin:
+            from neutron import manager
+            pf_plugin = (
+                manager.NeutronManager.load_class_for_provider(
+                    'neutron.service_plugins',
+                    'port_forwarding')())
+
         segments_plugin = ovn_nb_synchronizer.segments_plugin
 
         core_plugin.get_networks = mock.Mock()

--- a/neutron/tests/unit/plugins/ml2/drivers/ovn/mech_driver/ovsdb/test_ovsdb_monitor.py
+++ b/neutron/tests/unit/plugins/ml2/drivers/ovn/mech_driver/ovsdb/test_ovsdb_monitor.py
@@ -448,28 +448,32 @@ class TestOvnNbIdlNotifyHandler(test_mech_driver.OVNMechanismDriverTestCase):
         row_data.update({'up': True, 'enabled': False})
         self._test_lsp_helper('create', row_data)
         self.assertFalse(self.mech_driver.set_port_status_up.called)
-        self.mech_driver.set_port_status_down.assert_called_once_with('foo')
+        # SCI: don't expect explicit down status for new ports
+        self.mech_driver.set_port_status_down.assert_not_called()
         self.mech_driver.set_port_status_down.reset_mock()
 
         # down and enabled
         row_data.update({'up': False, 'enabled': True})
         self._test_lsp_helper('create', row_data)
         self.assertFalse(self.mech_driver.set_port_status_up.called)
-        self.mech_driver.set_port_status_down.assert_called_once_with('foo')
+        # SCI: don't expect explicit down status for new ports
+        self.mech_driver.set_port_status_down.assert_not_called()
         self.mech_driver.set_port_status_down.reset_mock()
 
         # down and disabled
         row_data.update({'up': False, 'enabled': False})
         self._test_lsp_helper('create', row_data)
         self.assertFalse(self.mech_driver.set_port_status_up.called)
-        self.mech_driver.set_port_status_down.assert_called_once_with('foo')
+        # SCI: don't expect explicit down status for new ports
+        self.mech_driver.set_port_status_down.assert_not_called()
         self.mech_driver.set_port_status_down.reset_mock()
 
         # Not set to up
         row_data.update({'up': ['set', []], 'enabled': True})
         self._test_lsp_helper('create', row_data)
         self.assertFalse(self.mech_driver.set_port_status_up.called)
-        self.mech_driver.set_port_status_down.assert_called_once_with('foo')
+        # SCI: don't expect explicit down status for new ports
+        self.mech_driver.set_port_status_down.assert_not_called()
 
     def test_unwatch_logical_switch_port_create_events(self):
         self.idl.unwatch_logical_switch_port_create_events()


### PR DESCRIPTION
    This commit removes the hardcoded ovn l3 plugin in the ovn-db-sync-util.
    In upstream neutron, the ovn l3 is enabled by defaut but not needed in
    our setup. removing the l3 plugin just syncs everyting else, like ports,
    QOS, security groups and networks.

    Furthermore, the changes introduce some bug fixes in the ovn_client,
    that sometimes accessd a None field or created a none entry in the OVN
    schema - which is unsupported.

    At last, I've skipped some parts of the mechanism driver initialisation
    when running inside rpc-server, since rpc-wrokers are not handling OVS
    callbacks.

- **[OVN] don't set explicit down status for ports that just got created**
- **[OVN] disable OVN l3, improve startup time, fix OVN db-sync**
- **[OVN] disable add_gw_port_info_to_logical_router_port maintenance task**