### PR TITLE
Allow ml2 drivers to start their own rpc listeners

### DIFF
--- a/neutron/plugins/ml2/managers.py
+++ b/neutron/plugins/ml2/managers.py
@@ -475,6 +475,12 @@ class MechanismManager(stevedore.named.NamedExtensionManager):
                 if not driver.obj.check_vlan_transparency(context):
                     raise vlan_exc.VlanTransparencyDriverError()
 
+    def start_driver_rpc_listeners(self):
+        servers = []
+        for driver in self.ordered_mech_drivers:
+            servers.extend(driver.obj.start_rpc_listeners())
+        return servers
+
     def _call_on_drivers(self, method_name, context,
                          continue_on_failure=False, raise_db_retriable=False):
         """Helper method for calling a method across all mechanism drivers.

--- a/neutron/plugins/ml2/plugin.py
+++ b/neutron/plugins/ml2/plugin.py
@@ -437,7 +437,10 @@ class Ml2Plugin(db_base_plugin_v2.NeutronDbPluginV2,
         self.conn.create_consumer(topics.REPORTS,
                                   [agents_db.AgentExtRpcCallback()],
                                   fanout=False)
-        return self.conn.consume_in_threads()
+
+        mech_driver_rpc = self.mechanism_manager.start_driver_rpc_listeners()
+
+        return self.conn.consume_in_threads() + mech_driver_rpc
 
     def start_rpc_state_reports_listener(self):
         self.conn_reports = n_rpc.Connection()

--- a/neutron/server/rpc_eventlet.py
+++ b/neutron/server/rpc_eventlet.py
@@ -34,7 +34,7 @@ def eventlet_rpc_server():
         manager.init()
         ext_mgr = extensions.PluginAwareExtensionManager.get_instance()
         ext_mgr.extend_resources("2.0", attributes.RESOURCES)
-        rpc_workers_launcher = service.start_all_workers()
+        rpc_workers_launcher = service.start_rpc_workers()
     except NotImplementedError:
         LOG.info("RPC was already started in parent process by "
                  "plugin.")

--- a/neutron/tests/unit/plugins/ml2/test_plugin.py
+++ b/neutron/tests/unit/plugins/ml2/test_plugin.py
@@ -4246,3 +4246,11 @@ class TestML2Segments(Ml2PluginV2TestCase):
             # Where new segment is part of segments
             self.assertIn(expected_segment,
                 observed_network[mpnet_apidef.SEGMENTS])
+
+
+class TestMl2PluginCallRPCMechanismDrivers(Ml2PluginV2TestCase):
+    def test_mech_driver_start_rpc_listeners_called(self):
+        with mock.patch.object(mech_test.TestMechanismDriver,
+                        'start_rpc_listeners') as mock_srl:
+            self.plugin.start_rpc_listeners()
+            mock_srl.assert_called_once()


### PR DESCRIPTION
Patch already upstream since 2024.2, backporting it. Our drivers should be compatible with this, but we should check that they don't start some extra interfaces we don't need. If this works, our own rpc calls will not only be handled by a single process per neutron-rpc-server, but by all of them.