### PR TITLE
Send Custom Notification to Nova

### DIFF
--- a/neutron/notifiers/nova.py
+++ b/neutron/notifiers/nova.py
@@ -251,6 +251,12 @@ class Notifier(object):
         self.batch_notifier.queue_event(event)
         port._notify_event = None
 
+    def send_custom_port_status(self, event):
+        if not isinstance(event, dict):
+            raise exc.InvalidInput(
+                error_message="Custom port status event must be a dict")
+        self.batch_notifier.queue_event(event)
+
     def notify_port_active_direct(self, port):
         """Notify nova about active port
 


### PR DESCRIPTION
To customize behavior in Nova’s server creation process, an effective approach is to send custom events that Nova can wait on.

In our case, we want to pause the server creation until the ML2 port binding
 (handled by the NSX-T agent) is completed.
This helps avoid a race condition.