### PR TITLE
linuxbridge: change default for port security enablement

### DIFF
--- a/neutron/plugins/ml2/drivers/linuxbridge/agent/arp_protect.py
+++ b/neutron/plugins/ml2/drivers/linuxbridge/agent/arp_protect.py
@@ -27,7 +27,7 @@ MAC_CHAIN_PREFIX = 'neutronMAC-'
 
 
 def setup_arp_spoofing_protection(vif, port_details):
-    if not port_details.get('port_security_enabled', True):
+    if not port_details.get('port_security_enabled', False):
         # clear any previous entries related to this port
         delete_arp_spoofing_protection([vif])
         LOG.info("Skipping ARP spoofing rules for port '%s' because "

--- a/neutron/tests/unit/plugins/ml2/drivers/linuxbridge/agent/test_arp_protect.py
+++ b/neutron/tests/unit/plugins/ml2/drivers/linuxbridge/agent/test_arp_protect.py
@@ -25,10 +25,12 @@ from neutron.tests import base
 VIF = 'vif_tap0'
 PORT_NO_SEC = {'port_security_enabled': False}
 PORT_TRUSTED = {'device_owner': constants.DEVICE_OWNER_ROUTER_GW}
-PORT = {'fixed_ips': [{'ip_address': '10.1.1.1'}],
+PORT = {'port_security_enabled': True,
+        'fixed_ips': [{'ip_address': '10.1.1.1'}],
         'device_owner': 'nobody',
         'mac_address': '00:11:22:33:44:55'}
-PORT_ADDR_PAIR = {'fixed_ips': [{'ip_address': '10.1.1.1'}],
+PORT_ADDR_PAIR = {'port_security_enabled': True,
+                  'fixed_ips': [{'ip_address': '10.1.1.1'}],
                   'device_owner': 'nobody',
                   'mac_address': '00:11:22:33:44:55',
                   'allowed_address_pairs': [


### PR DESCRIPTION
The so far default enabled port security even without enabled
port-security extension. This hides the port security configuration
since the API is incorrectly showing port security as disabled. To
prevent this confusion, port security is now disabled by default.