### PR TITLE
rpc: change default for port security

### DIFF
--- a/neutron/plugins/ml2/rpc.py
+++ b/neutron/plugins/ml2/rpc.py
@@ -175,7 +175,7 @@ class RpcCallbacks(type_tunnel.TunnelRpcCallbackMixin):
                  'fixed_ips': port['fixed_ips'],
                  'device_owner': port['device_owner'],
                  'allowed_address_pairs': port['allowed_address_pairs'],
-                 'port_security_enabled': port.get(psec.PORTSECURITY, True),
+                 'port_security_enabled': port.get(psec.PORTSECURITY, False),
                  qos_consts.QOS_POLICY_ID: port.get(qos_consts.QOS_POLICY_ID),
                  qos_consts.QOS_NETWORK_POLICY_ID: qos_network_policy_id,
                  'profile': port[portbindings.PROFILE],


### PR DESCRIPTION
Modify the general default for port security in the rpc server.

The previous commit changed only the defaults for the linuxbridge agent.
However, the rpc server also needs to be updated to ensure that the
default for port security is consistent.

fixes: 34819de
