### PR TITLE
Remove raven from custom requirements

### DIFF
--- a/custom-requirements.txt
+++ b/custom-requirements.txt
@@ -5,7 +5,6 @@ jaeger-client
 dumb-init
 
 # sentry client
-raven
 git+https://github.com/sapcc/sentrylogger.git@main#egg=sapcc_sentrylogger
 
 # agent checks for neutron


### PR DESCRIPTION
We no longer use raven, but use sentrylogger instead.