### PR TITLE
Move away from editable custom requirements

### DIFF
--- a/custom-requirements.txt
+++ b/custom-requirements.txt
@@ -29,14 +29,14 @@ git+https://github.com/sapcc/openstack-uwsgi-middleware.git@main#egg=uwsgi-middl
 git+https://github.com/sapcc/openstack-rate-limit-middleware.git#egg=rate-limit-middleware
 
 # Networking Drivers
--e git+https://github.com/sapcc/asr1k-neutron-l3@stable/2024.1-m3#egg=asr1k-neutron-l3
--e git+https://github.com/sapcc/networking-aci.git@stable/2024.1-m3#egg=networking_aci[acicobra]
--e git+https://github.com/sapcc/networking-manila.git@stable/2024.1-m3#egg=networking_manila
--e git+https://github.com/sapcc/networking-f5.git@stable/2024.1-m3#egg=networking_f5
--e git+https://github.com/sapcc/networking-arista.git@stable/2024.1-m3#egg=networking_arista
--e git+https://github.com/sapcc/networking-nsx-t.git@stable/2024.1-m3#egg=networking_nsxv3
--e git+https://github.com/sapcc/networking-bgpvpn@stable/2024.1-m3#egg=networking-bgpvpn
--e git+https://github.com/sapcc/networking-interconnection@stable/2024.1-m3#egg=networking_interconnection
--e git+https://github.com/sapcc/networking-ccloud@stable/2024.1-m3#egg=networking_ccloud
--e git+https://github.com/sapcc/neutron-fwaas@stable/2024.1-m3#egg=neutron_fwaas
--e git+https://github.com/sapcc/neutron-vpnaas@stable/2024.1-m3#egg=neutron_vpnaas
+asr1k-neutron-l3 @ git+https://github.com/sapcc/asr1k-neutron-l3@stable/2024.1-m3
+networking_aci[acicobra] @ git+https://github.com/sapcc/networking-aci.git@stable/2024.1-m3
+networking_manila @ git+https://github.com/sapcc/networking-manila.git@stable/2024.1-m3
+networking_f5 @ git+https://github.com/sapcc/networking-f5.git@stable/2024.1-m3
+networking_arista @ git+https://github.com/sapcc/networking-arista.git@stable/2024.1-m3
+networking_nsxv3 @ git+https://github.com/sapcc/networking-nsx-t.git@stable/2024.1-m3
+networking-bgpvpn @ git+https://github.com/sapcc/networking-bgpvpn@stable/2024.1-m3
+networking_interconnection @ git+https://github.com/sapcc/networking-interconnection@stable/2024.1-m3
+networking_ccloud @ git+https://github.com/sapcc/networking-ccloud@stable/2024.1-m3
+neutron-fwaas @ git+https://github.com/sapcc/neutron-fwaas@stable/2024.1-m3
+neutron-vpnaas @ git+https://github.com/sapcc/neutron-vpnaas@stable/2024.1-m3


### PR DESCRIPTION
We don't to install our custom requirements as editable and it is causing some problems in the ci with other packages depending on these packages without specifying them as editable.