### PR TITLE
Remove pkg_sources use from Neutron and still pin virtualenv

### DIFF
--- a/neutron/agent/linux/iptables_manager.py
+++ b/neutron/agent/linux/iptables_manager.py
@@ -487,7 +487,8 @@ class IptablesManager(object):
                                    privsep_exec=True).split('\n')
 
     def _get_version(self):
-        # Output example is "iptables v1.6.2"
+        # Output example is "iptables v1.8.7 (nf_tables)",
+        # this will return "1.8.7"
         args = ['iptables', '--version']
         version = str(linux_utils.execute(
             args, run_as_root=True, privsep_exec=True).split()[1][1:])

--- a/neutron/common/utils.py
+++ b/neutron/common/utils.py
@@ -50,8 +50,8 @@ from oslo_utils import encodeutils
 from oslo_utils import excutils
 from oslo_utils import timeutils
 from oslo_utils import uuidutils
+from oslo_utils import versionutils
 from osprofiler import profiler
-import pkg_resources
 from sqlalchemy.dialects.mysql import dialect as mysql_dialect
 from sqlalchemy.dialects.postgresql import dialect as postgresql_dialect
 from sqlalchemy.dialects.sqlite import dialect as sqlite_dialect
@@ -356,8 +356,8 @@ def get_socket_address_family(ip_version):
 
 def is_version_greater_equal(version1, version2):
     """Returns True if version1 is greater or equal than version2 else False"""
-    return (pkg_resources.parse_version(version1) >=
-            pkg_resources.parse_version(version2))
+    return (versionutils.convert_version_to_tuple(version1) >=
+            versionutils.convert_version_to_tuple(version2))
 
 
 class DelayedStringRenderer(object):

--- a/neutron/conf/db/migration_cli.py
+++ b/neutron/conf/db/migration_cli.py
@@ -10,16 +10,21 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import sys
+
 from oslo_config import cfg
-import pkg_resources
 
 from neutron._i18n import _
 
+if sys.version_info < (3, 10, 0):
+    from importlib_metadata import entry_points
+else:
+    from importlib.metadata import entry_points
 
 MIGRATION_ENTRYPOINTS = 'neutron.db.alembic_migrations'
 migration_entrypoints = {
     entrypoint.name: entrypoint
-    for entrypoint in pkg_resources.iter_entry_points(MIGRATION_ENTRYPOINTS)
+    for entrypoint in entry_points(group=MIGRATION_ENTRYPOINTS)
 }
 
 INSTALLED_SUBPROJECTS = list(migration_entrypoints)

--- a/neutron/db/migration/cli.py
+++ b/neutron/db/migration/cli.py
@@ -564,13 +564,13 @@ def _get_installed_entrypoint(subproject):
 def _get_subproject_script_location(subproject):
     '''Get the script location for the installed subproject.'''
     entrypoint = _get_installed_entrypoint(subproject)
-    return ':'.join([entrypoint.module_name, entrypoint.attrs[0]])
+    return ':'.join([entrypoint.module, entrypoint.attr])
 
 
 def _get_subproject_base(subproject):
     '''Get the import base name for the installed subproject.'''
     entrypoint = _get_installed_entrypoint(subproject)
-    return entrypoint.module_name.split('.')[0]
+    return entrypoint.module.split('.')[0]
 
 
 def get_alembic_version_table(config):

--- a/neutron/tests/unit/db/test_migration.py
+++ b/neutron/tests/unit/db/test_migration.py
@@ -14,6 +14,7 @@
 #    under the License.
 
 import copy
+import importlib.metadata
 import os
 import re
 import sys
@@ -28,7 +29,6 @@ import fixtures
 from neutron_lib import fixture as lib_fixtures
 from neutron_lib.utils import helpers
 from oslo_utils import fileutils
-import pkg_resources
 import sqlalchemy as sa
 from testtools import matchers
 
@@ -143,13 +143,13 @@ class TestCli(base.BaseTestCase):
             config = alembic_config.Config(ini)
             config.set_main_option('neutron_project', project)
             module_name = project.replace('-', '_') + '.db.migration'
-            attrs = ('alembic_migrations',)
-            script_location = ':'.join([module_name, attrs[0]])
+            script_location = ':'.join([module_name, 'alembic_migrations'])
             config.set_main_option('script_location', script_location)
             self.configs.append(config)
-            entrypoint = pkg_resources.EntryPoint(project,
-                                                  module_name,
-                                                  attrs=attrs)
+            entrypoint = importlib.metadata.EntryPoint(
+                name=project,
+                group='neutron.db.alembic_migrations',
+                value=script_location)
             migration_cli.migration_entrypoints[project] = entrypoint
 
     def _main_test_helper(self, argv, func_name, exp_kwargs=[{}]):

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,10 @@ envlist = docs,py3,pep8
 minversion = 3.18.0
 ignore_basepython_conflict = True
 
+# specify virtualenv here to keep local runs consistent with the
+# gate (it sets the versions of pip, setuptools, and wheel)
+requires = virtualenv<20.38
+
 [testenv]
 basepython = {env:TOX_PYTHON:python3}
 setenv = VIRTUAL_ENV={envdir}


### PR DESCRIPTION
This packports two upstream patches to remove `pkg_resources` usage from Neutron. We still need it, as at the moment the pep8 check uses a flake8 version that still requires `pkg_resources`. As all of this will go away anyway with the next major version bump I'm just going to go ahead and pin virtualenv in tox as with our other repos.