### PR TITLE
Improve convergence when migrating w/ linuxbridge

### DIFF
--- a/neutron/plugins/ml2/rpc.py
+++ b/neutron/plugins/ml2/rpc.py
@@ -26,6 +26,7 @@ from neutron_lib.services.qos import constants as qos_consts
 from oslo_config import cfg
 from oslo_log import log
 import oslo_messaging
+from oslo_serialization import jsonutils
 from osprofiler import profiler
 from sqlalchemy.orm import exc
 
@@ -152,9 +153,10 @@ class RpcCallbacks(type_tunnel.TunnelRpcCallbackMixin):
                          'vif_type': port_context.vif_type})
             return {'device': device}
 
+        migrating_to = _get_migrating_to_from_port(port)
         if (port['device_owner'].startswith(
                 n_const.DEVICE_OWNER_COMPUTE_PREFIX) and
-                port[portbindings.HOST_ID] != host):
+                port[portbindings.HOST_ID] != host and migrating_to != host):
             LOG.debug("Device %(device)s has no active binding in host "
                       "%(host)s", {'device': device,
                                    'host': host})
@@ -514,3 +516,17 @@ class AgentNotifierApi(dvr_rpc.DVRAgentRpcApiMixin,
         cctxt = self.client.prepare(topic=self.topic_port_binding_activate,
                                     fanout=True, version='1.5')
         cctxt.cast(context, 'binding_activate', port_id=port_id, host=host)
+
+
+def _get_migrating_to_from_port(port):
+    profile = port.get(portbindings.PROFILE)
+    if not profile:
+        return None
+    if isinstance(profile, str):
+        try:
+            profile = jsonutils.loads(profile)
+        except ValueError:
+            return None
+    migrating_to = profile.get("migrating_to")
+
+    return migrating_to

--- a/neutron/tests/unit/plugins/ml2/test_rpc.py
+++ b/neutron/tests/unit/plugins/ml2/test_rpc.py
@@ -163,6 +163,16 @@ class RpcCallbacksTestCase(base.BaseTestCase):
         res = self.callbacks.get_device_details(mock.Mock(), host='host')
         self.assertIn(constants.NO_ACTIVE_BINDING, res)
 
+    def test_get_device_details_port_honor_migrating_to(self):
+        port = collections.defaultdict(lambda: 'fake_port')
+        self.plugin.get_bound_port_context().current = port
+        port['device_owner'] = constants.DEVICE_OWNER_COMPUTE_PREFIX
+        port[portbindings.HOST_ID] = 'other-host'
+        port[portbindings.PROFILE] = {'migrating_to': 'host'}
+        res = self.callbacks.get_device_details(mock.Mock(), host='host')
+        self.assertNotIn(constants.NO_ACTIVE_BINDING, res)
+        self.assertIn('port_id', res)
+
     def test_get_device_details_qos_policy_id_from_port(self):
         port = collections.defaultdict(
             lambda: 'fake_port',


### PR DESCRIPTION
Improve convergence when migrating w/ linuxbridge

When we migrate a vm between two kvm hypervisors that are using the
linuxbridge driver, we need to make sure that the network is present
when the vm comes up. This is important so the VMs/HVs rARP packets are
send out and the network fabric behind the HV knows where to find the VM
after a migration.

With linuxbridge and Nova it is not clear who actually creates the
bridge and adds the tap interface to it. Generally it seems to be that
Nova does this first and Neutron only discovers this in one of its
agent's loops. But here we have a problem: The bond is only created and
put into the bridge once the port binding is active. It seems like OVS
had a similar problem, which was patched here[0]. The code looks very
similar to our problematic piece of code, so we adapt the idea: The port
is not only bound if the host of the port matches, but also if the
migrating_to field from the binding profile matches the host. This helps
us getting the bond faster into the bridge. Additionally, we can - via
config - increase the polling timeout of the linuxbridge agent to make
sure we do our deed as fast as possible.

Our patch looks a bit different from [0]: We don't fetch the active
bindings, as all the information we need is already present in the port
dict that we have. In some cases (at least in the tests) the profile
might be a string and not already a json-decoded data structure, so we
need to do the decoding ourselves in some cases (same as [0]).

As a midterm solution it would probably make sense to get this done in a
quicker, more reactive fashion (i.e. not wait for a loop, but directly
react on the event). Another option would be to migrate away from
linuxbridge, but one step after the other.

Note that this is only happening on "cold" hosts, which have never seen
the OpenStack network so far. Linuxbridge does not seem to clean up the
bridge or bond interface (which might also be something which we need to
look into in the future).

[0] https://github.com/openstack/neutron/commit/f8a22c7d4aa654eaad3b683073849c873ea3beff
