### PR TITLE
[dhcp-agent] support DhcpAgentWithStateReport to be marked unschedulable

### DIFF
--- a/neutron/agent/dhcp/agent.py
+++ b/neutron/agent/dhcp/agent.py
@@ -1091,7 +1091,9 @@ class DhcpAgentWithStateReport(DhcpAgent):
             'configurations': {
                 'dhcp_driver': self.conf.dhcp_driver,
                 'dhcp_lease_duration': self.conf.dhcp_lease_duration,
-                'log_agent_heartbeats': self.conf.AGENT.log_agent_heartbeats},
+                'log_agent_heartbeats': self.conf.AGENT.log_agent_heartbeats,
+                'scheduling_disabled': self.conf.AGENT.scheduling_disabled,
+            },
             'start_flag': True,
             'agent_type': constants.AGENT_TYPE_DHCP}
         report_interval = self.conf.AGENT.report_interval

--- a/neutron/conf/agent/dhcp.py
+++ b/neutron/conf/agent/dhcp.py
@@ -141,8 +141,17 @@ DNSMASQ_OPTS = [
                        "a default gateway.")),
 ]
 
+DHCP_AGENT_STATE_OPTS = [
+    # we want this only for the dhcp-agent, so we are not adding that to
+    # AGENT_STATE_OPTS in register_agent_state_opts_helper()
+    cfg.BoolOpt('scheduling_disabled', default=False,
+                help="No (new) networks will be scheduled automatically "
+                     "on this dhcp-agent."),
+]
+
 
 def register_agent_dhcp_opts(cfg=cfg.CONF):
+    cfg.register_opts(DHCP_AGENT_STATE_OPTS, 'AGENT')
     cfg.register_opts(DHCP_AGENT_OPTS)
     cfg.register_opts(DHCP_OPTS)
     cfg.register_opts(DNSMASQ_OPTS)

--- a/neutron/scheduler/dhcp_agent_scheduler.py
+++ b/neutron/scheduler/dhcp_agent_scheduler.py
@@ -266,6 +266,28 @@ class DhcpFilter(base_resource_filter.BaseResourceFilter):
                             if agent['host'] in hostable_dhcp_hosts]
         return reachable_agents
 
+    def _filter_agents_where_scheduling_disabled(self, dhcp_agent_candidates):
+        """Remove agents from list where 'scheduling_disabled' is True."""
+
+        schedulable_agents = []
+        disabled_hosts = []
+
+        # We do not want any networks to get scheduled on agents
+        # where we have scheduling disabled. Filter those out.
+        for candidate in dhcp_agent_candidates:
+            if not candidate.configurations.get(
+                    'scheduling_disabled', False):
+                schedulable_agents.append(candidate)
+            else:
+                disabled_hosts.append(candidate.host)
+
+        if disabled_hosts:
+            LOG.debug('Ignoring agent hosts %s in DhcpFilter, '
+                      'scheduling of those dhcp-agents is disabled',
+                      ', '.join(disabled_hosts))
+
+        return schedulable_agents
+
     def _get_dhcp_agents_hosting_network(self, plugin, context, network):
         """Return dhcp agents hosting the given network or None if a given
            network is already hosted by enough number of agents.
@@ -319,6 +341,10 @@ class DhcpFilter(base_resource_filter.BaseResourceFilter):
             agent for agent in active_dhcp_agents
             if agent.id not in hosted_agent_ids and plugin.is_eligible_agent(
                 context, True, agent)]
+
+        hostable_dhcp_agents = self._filter_agents_where_scheduling_disabled(
+                hostable_dhcp_agents)
+
         hostable_dhcp_agents = self._filter_agents_with_network_access(
             plugin, context, network, hostable_dhcp_agents)
 

--- a/neutron/tests/common/helpers.py
+++ b/neutron/tests/common/helpers.py
@@ -82,7 +82,8 @@ def register_l3_agent(host=HOST, agent_mode=constants.L3_AGENT_MODE_LEGACY,
     return _register_agent(agent)
 
 
-def _get_dhcp_agent_dict(host, networks=0, az=DEFAULT_AZ):
+def _get_dhcp_agent_dict(host, networks=0, az=DEFAULT_AZ,
+                         scheduling_disabled=None):
     agent = {
         'binary': constants.AGENT_PROCESS_DHCP,
         'host': host,
@@ -91,13 +92,16 @@ def _get_dhcp_agent_dict(host, networks=0, az=DEFAULT_AZ):
         'availability_zone': az,
         'configurations': {'dhcp_driver': 'dhcp_driver',
                            'networks': networks}}
+    if scheduling_disabled is not None:
+        agent['configurations']['scheduling_disabled'] = scheduling_disabled
     return agent
 
 
 def register_dhcp_agent(host=HOST, networks=0, admin_state_up=True,
-                        alive=True, az=DEFAULT_AZ):
+                        alive=True, az=DEFAULT_AZ, scheduling_disabled=None):
     agent = _register_agent(
-        _get_dhcp_agent_dict(host, networks, az=az))
+        _get_dhcp_agent_dict(host, networks, az=az,
+                             scheduling_disabled=scheduling_disabled))
 
     if not admin_state_up:
         set_agent_admin_state(agent['id'])

--- a/neutron/tests/unit/scheduler/test_dhcp_agent_scheduler.py
+++ b/neutron/tests/unit/scheduler/test_dhcp_agent_scheduler.py
@@ -129,6 +129,61 @@ class TestDhcpScheduler(TestDhcpSchedulerBaseTestCase):
                 scheduler.schedule(
                     plugin, self.ctx, network))
 
+    def test_no_schedule_on_unschedulable_agent(self):
+        """When a dhcp-agent is marked with 'scheduling disabled', we
+           do not want it to be selected for automatic scheduling.
+           This tests that those agents are filtered out but regular
+           agents are still being chosen.
+        """
+
+        az = helpers.DEFAULT_AZ
+        network = {'id': self.network_id}
+
+        plugin = mock.Mock()
+        plugin.get_network.return_value = self.network
+        plugin.filter_hosts_with_network_access.side_effect = (
+            lambda context, network_id, hosts: hosts)
+        plugin.get_dhcp_agents_hosting_networks.return_value = []
+
+        agent_nosched = helpers.register_dhcp_agent(
+                'host-a',
+                admin_state_up=True, alive=True,
+                az=az, scheduling_disabled=True)
+
+        agent_okay = helpers.register_dhcp_agent(
+                'host-b',
+                admin_state_up=True, alive=True,
+                az=az)
+
+        # Check if the configuration is applied correctly, but
+        # only to the one agent we want. This is testing if the
+        # modified helper returns correct agents for the tests.
+        no_sched_kwd = 'scheduling_disabled'
+        self.assertNotIn(no_sched_kwd, agent_okay.configurations)
+        self.assertIn(no_sched_kwd, agent_nosched.configurations)
+        self.assertTrue(agent_nosched.configurations.get(no_sched_kwd))
+
+        # The real tests start here:
+
+        # 1. Assert that we are still able to schedule to a regular agent
+        #    when there is a non-schedulable one present.
+        plugin.get_agent_objects.return_value = [agent_nosched, agent_okay]
+        scheduler = dhcp_agent_scheduler.ChanceScheduler()
+
+        # The one regular agent should still be available to host the network.
+        self.assertEqual([agent_okay],
+                         scheduler.schedule(plugin, self.ctx, network)
+                         )
+
+        # 2. Assert that we do not schedule on a 'scheduling_disabled' agent:
+        plugin.get_agent_objects.return_value = [agent_nosched]
+        scheduler = dhcp_agent_scheduler.ChanceScheduler()
+
+        # No agent should be available to host the network.
+        self.assertEqual([],
+                         scheduler.schedule(plugin, self.ctx, network)
+                         )
+
     def test_network_rescheduled_when_db_returns_active_hosts(self):
         self._test_reschedule_vs_network_on_dead_agent(True)
 


### PR DESCRIPTION
Admin-shutting an agent leads to the agent being completely vacated.

However we have cases in which we want an agent to stay online, but prevent any new workloads to be scheduled on it. This can be a capacity consideration or because it is meant to be decomissioned.

In addition this allows us in the dev environment to replace agents with experimental versions, without causing disruption. It is still possible to manually schedule a network on this dhcp-agent for testing.

A similar feature was implemented for asr1k-neutron-l3 here:

https://github.com/sapcc/asr1k-neutron-l3/commit/425cc812a7b9d0ccb43c367c0c3adce0e85873be

Note: We are not filtering in `AutoScheduler.auto_schedule_networks`. 
This method gets called with the host as parameter, so the scheduling decision is already made.