### PR TITLE
support individual custom network settings per domain for edns logging and DNS

### DIFF
--- a/neutron/api/rpc/handlers/dhcp_rpc.py
+++ b/neutron/api/rpc/handlers/dhcp_rpc.py
@@ -14,9 +14,11 @@
 # limitations under the License.
 
 import copy
+from dataclasses import dataclass
 import ipaddress
 import itertools
 import operator
+import pathlib
 
 from keystoneauth1 import loading as ks_loading
 from neutron_lib.api.definitions import portbindings
@@ -34,6 +36,7 @@ from oslo_db import exception as db_exc
 from oslo_log import log as logging
 import oslo_messaging
 from oslo_utils import excutils
+import yaml
 
 from neutron._i18n import _
 from neutron.common import utils
@@ -50,18 +53,277 @@ class DomainLookupFailed(Exception):
     pass
 
 
+class CustomNetworkConfigError(Exception):
+    pass
+
+
+@dataclass
+class CustomNetworkSettings:
+    dns_ednslogging_enabled: bool
+    dns_custom_upstreams: set[str] | None = None
+
+    def __post_init__(self):
+        if not isinstance(self.dns_ednslogging_enabled, bool):
+            raise TypeError(_("dns_ednslogging_enabled must be a bool: %s")
+                            % self.dns_ednslogging_enabled)
+        if self.dns_custom_upstreams:
+            self._validate_upstreams()
+
+    def _validate_upstreams(self):
+        """ensure that all elements are valid IP addresses and make it a
+        set of strings containing the normalized IP addresses.
+        """
+        if not self.dns_custom_upstreams:
+            self.dns_custom_upstreams = set()
+            return
+
+        addrs: set[str] = set()
+        for item in self.dns_custom_upstreams:
+            try:
+                addr = ipaddress.ip_address(item)
+                addrs.add(addr.compressed)
+            except ValueError:
+                LOG.error("not a valid IP for DNS entry: %s", item)
+                raise
+
+        self.dns_custom_upstreams = addrs
+
+
 class CustomNetworkConfigurator:
 
     def __init__(self):
         self._KEYSTONE = None
         self._domain_id_cache = {}
         self._domain_name_cache = {}
+        self._dns_config: dict[str, dict[str, CustomNetworkSettings]] = {}
+        self._config_file = cfg.CONF.customdns.config_file
+        self._load_config()
+
+    def _load_config(self):
+        """load or reload custom dns config from file."""
+
+        if not self._config_file:
+            return
+
+        LOG.debug("loading customdns config from '%s'", self._config_file)
+
+        try:
+            cfgfile = pathlib.Path(self._config_file)
+            config = yaml.load(cfgfile.read_bytes(), Loader=yaml.SafeLoader)
+        except IOError as e:
+            raise CustomNetworkConfigError(_("failed to load "
+                                             "config file '%s': %s")
+                                           % (self._config_file, e))
+        if not config:
+            msg = (_("failed to load config file '%s': empty file?")
+                   % self._config_file)
+            raise CustomNetworkConfigError(msg)
+
+        # make an empty config file fail hard
+        try:
+            matches = config['matches']
+        except KeyError:
+            msg = (_("Missing 'matches:' in custom DNS config file '%s'") %
+                   self._config_file)
+            raise CustomNetworkConfigError(msg)
+
+        # but accept an intentionally empty list
+        if not matches:
+            return
+
+        dns_config = {'projects': {}, 'domains': {}}
+
+        mandatory_keys = {'ednslogging', }
+        valid_keys = mandatory_keys | {
+                      'project_ids',
+                      'domain_name_prefixes',
+                      'upstream_dns_servers'
+                    }
+
+        for item in matches:
+            # Each match config consists of three (optional) items
+            # project_ids, domain_name_prefixes and upstream_dns_servers and
+            # one mandatory setting ednslogging.
+            # If project id _or_ domain prefix match, the upstream dns_servers
+            # and ednslogging setting will be applied to the network.
+
+            invalid_keys = item.keys() - valid_keys
+            if invalid_keys:
+                msg = (_("Invalid key(s) in config file '%s' at '%s': %s")
+                       % (self._config_file, item,
+                          ", ".join(list(invalid_keys))))
+                raise CustomNetworkConfigError(msg)
+
+            missing_keys = mandatory_keys - item.keys()
+            if missing_keys:
+                msg = (_("Missing key(s) in config file '%s' at '%s': %s")
+                       % (self._config_file, item,
+                          ", ".join(list(missing_keys))))
+                raise CustomNetworkConfigError(msg)
+
+            project_ids = item.get('project_ids', [])
+            domain_prefixes = item.get('domain_name_prefixes', [])
+            upstreams = item.get('upstream_dns_servers', [])
+            ednslogging = item['ednslogging']
+
+            try:
+                netconfig = CustomNetworkSettings(
+                    dns_ednslogging_enabled=ednslogging,
+                    dns_custom_upstreams=set(upstreams),
+                )
+            except (TypeError, ValueError) as e:
+                msg = _("Error parsing custom DNS config: %s") % e
+                raise CustomNetworkConfigError(msg)
+
+            for project_id in project_ids:
+                if project_id in dns_config['projects']:
+                    msg = _("project %s already configured!") % project_id
+                    raise CustomNetworkConfigError(msg)
+
+                dns_config['projects'][project_id] = netconfig
+
+            for domain_prefix in domain_prefixes:
+                if domain_prefix in dns_config['domains']:
+                    msg = (_("domain-prefix '%s' already configured!")
+                           % domain_prefix)
+                    raise CustomNetworkConfigError(msg)
+
+                dns_config['domains'][domain_prefix] = netconfig
+
+        self._dns_config = dns_config
 
     def add_dnssettings_to_net(self, network_dict):
         """Add custom dns settings to the network if the network
         is found to be part of one of the custom OpenStack domains
         or projects from our settings.
         """
+
+        # TODO(mutax): after migration replace this whole method with
+        #              the method '_add_external_dnssettings_to_net'
+
+        # check if we got an external custom dns config
+        if self._dns_config:
+            self._add_external_dnssettings_to_net(network_dict)
+        else:
+            self._add_legacy_dnssettings_to_net(network_dict)
+
+    def _add_external_dnssettings_to_net(self, network_dict):
+        """Add custom dns settings specified via external config file
+        to the network, if the network matches the criteria set in the
+        config file.
+        """
+
+        if not self._dns_config:
+            return
+
+        # first check if we have a match in the project ids,
+        # this is the cheapest lookup
+        if self._apply_project_settings(network_dict):
+            return
+
+        # next try to match openstack domain name prefixes.
+        self._apply_domain_settings(network_dict)
+
+    def _apply_project_settings(self, network_dict: dict) -> bool:
+        """apply project-specific DNS settings if they exist.
+        Returns True if settings were found to allow skipping of
+        further processing. Not to be called directly.
+        """
+
+        if not self._dns_config:
+            return False
+
+        project_id = network_dict['project_id']
+
+        # check if the project-id matches the list for custom settings
+        custom_config = self._dns_config['projects'].get(project_id)
+        if custom_config:
+            LOG.debug("setting custom settings for net %s, "
+                      "project %s matches: %s",
+                      network_dict['id'], project_id, custom_config
+                      )
+
+            network_dict['dns_ednslogging_enabled'] = (
+                custom_config.dns_ednslogging_enabled)
+
+            if custom_config.dns_custom_upstreams:
+                network_dict['dns_custom_upstreams'] = (
+                    custom_config.dns_custom_upstreams)
+            return True
+
+        return False
+
+    def _apply_domain_settings(self, network_dict: dict) -> bool:
+        """apply domain-specific DNS settings if they exist.
+        Returns True if settings were found to allow skipping of
+        further processing for consistency. Not to be called directly.
+        """
+
+        if not self._dns_config:
+            return False
+
+        # try to retrieve the OpenStack domain name via the project id,
+        # this uses a local cache and on a cache miss queries keystone
+        project_id = network_dict['project_id']
+        domain_name = None
+        try:
+            domain_name = self.get_domain_name(project_id)
+        except Exception as e:  # noqa
+            # If Keystone is not reachable or something goes wrong with
+            # the lookup, we do not want to fail configuring all networks.
+            # Currently, the sane thing to do is using default settings in
+            # those cases. As we want to fail to the default in all error
+            # cases anyway, we can use a bare Exception here.
+            # TODO(mutax): I do want to get the stack trace logged, but I
+            #   also want to get a nice warning to the log independent of the
+            #   source of the error - but now we log the same error twice.
+            LOG.exception('Failed to retrieve domain to set custom dns for'
+                          ' project %s of network %s - %s: %s',
+                          project_id, network_dict['id'], type(e), e
+                          )
+
+        # in case of an error or empty result, we fall back to the 'safe'
+        # side by using default settings.
+        if not domain_name:
+            LOG.warning('Unable to retrieve domain name for project %s,'
+                        ' falling back to default settings for network %s',
+                        project_id, network_dict['id'])
+            return False
+
+        # check if the OpenStack domain name starts with one of the prefixes
+        # from our config (or is equal).
+        # we are now doing a longest prefix match, allowing defaults to be set
+        # i.e. abc- can provide settings for all domains starting with abc,
+        # while at the same time abc-123 can be used to match a specific one
+
+        for domain_prefix in sorted(self._dns_config['domains'].keys(),
+                                    key=len,
+                                    reverse=True):
+
+            if domain_name.startswith(domain_prefix):
+                custom_config = self._dns_config['domains'][domain_prefix]
+
+                LOG.debug("setting custom settings for net %s, "
+                          "domain %s matches prefix %s: %s",
+                          network_dict['id'], domain_name,
+                          domain_prefix, custom_config
+                          )
+
+                network_dict['dns_ednslogging_enabled'] = (
+                    custom_config.dns_ednslogging_enabled)
+
+                if custom_config.dns_custom_upstreams:
+                    network_dict['dns_custom_upstreams'] = (
+                        custom_config.dns_custom_upstreams)
+                return True
+        return False
+
+    def _add_legacy_dnssettings_to_net(self, network_dict):
+        """If the network domain or project match the configured list,
+        apply custom dns servers to the configuration.
+        Legacy method to be removed after deployment of the new config files.
+        """
+        # TODO(mutax): remove this method after migration to new config file
 
         if not (cfg.CONF.customdns.domain_name_prefixes or
                 cfg.CONF.customdns.project_ids):
@@ -179,6 +441,8 @@ class CustomNetworkConfigurator:
            directly match on the id.
         """
         project_id = network_dict['project_id']
+
+        # TODO(mutax): remove this method after migration to new config file
 
         # should not happen, but would never match anyway
         if not project_id:

--- a/neutron/conf/service.py
+++ b/neutron/conf/service.py
@@ -59,13 +59,21 @@ DNSSETTINGS_CONF_SECTION = 'customdns'
 DNSSETTINGS_OPTS = [
     cfg.BoolOpt('enabled',
                 default=False,
-                help=_("Enable domain specific DNS settings")),
+                help=_("Enable domain specific DNS settings.")),
+    # TODO(mutax): remove deprecated options after migration to config file
     cfg.ListOpt('upstream_dns_servers', default=[],
-                help=_("Custom upstream DNS server IPs")),
+                help=_("Custom upstream DNS server IPs"
+                       " (deprecated, use config_file)")),
     cfg.ListOpt('domain_name_prefixes', default=[],
-                help=_("OS Domain Name Prefixes to match against")),
+                help=_("OS Domain Name Prefixes to match against"
+                       " (deprecated, use config_file)")),
     cfg.ListOpt('project_ids', default=[],
-                help=_("IDs of projects to match for testing only")),
+                help=_("IDs of projects to match for testing only"
+                       " (deprecated, use config_file)")),
+    cfg.StrOpt('config_file', default=None,
+               help=_("Path to yaml config file for OpenStack domain "
+                      "or project specific DNS settings.")
+               ),
 ]
 
 

--- a/neutron/tests/unit/api/rpc/handlers/test_dhcp_rpc.py
+++ b/neutron/tests/unit/api/rpc/handlers/test_dhcp_rpc.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import operator
+import pathlib
 
 from collections import UserDict
 from unittest import mock
@@ -30,7 +31,9 @@ from oslo_messaging.rpc import dispatcher as rpc_dispatcher
 from oslo_utils import uuidutils
 
 from neutron.api.rpc.handlers import dhcp_rpc
+from neutron.api.rpc.handlers.dhcp_rpc import CustomNetworkConfigError
 from neutron.api.rpc.handlers.dhcp_rpc import CustomNetworkConfigurator
+from neutron.api.rpc.handlers.dhcp_rpc import CustomNetworkSettings
 from neutron.common import utils
 from neutron.db import provisioning_blocks
 from neutron.objects import network as network_obj
@@ -58,10 +61,148 @@ class TestDhcpRpcCustomNetworkConfigurator(base.BaseTestCase):
 
         self.assertFalse(bool(empty_dict))
 
+    @mock.patch.object(pathlib.Path, 'read_bytes')
+    def test_external_yaml_config_parser(self, mock_pathlib):
+        """Basic tests for an empty, invalid or on-purpose empty
+        config file.
+        """
+
+        cfg.CONF.set_override('enabled', True,
+                              group='customdns')
+        # just needs to be set and a valid filename,
+        # return data is mocked above.
+        cfg.CONF.set_override('config_file', 'irrelevant.yaml',
+                              group='customdns')
+
+        empty_config = b""
+
+        mock_pathlib.return_value = empty_config
+        self.assertRaises(CustomNetworkConfigError, CustomNetworkConfigurator)
+
+        invalid_config = b"""
+                          foobar:
+                        """
+
+        mock_pathlib.return_value = invalid_config
+        self.assertRaises(CustomNetworkConfigError, CustomNetworkConfigurator)
+
+        no_config = b"""
+                     matches:
+                    """
+
+        mock_pathlib.return_value = no_config
+        cnc = CustomNetworkConfigurator()
+        self.assertEqual({}, cnc._dns_config)
+
+    def _get_cnc_from_yaml_config(self, configdata: bytes)\
+            -> CustomNetworkConfigurator:
+        """returns a CustomNetworkConfigurator instance
+        using the configuration in configdata provided as raw binary yaml
+        """
+
+        cfg.CONF.set_override('enabled', True,
+                              group='customdns')
+        # just needs to be set and a valid filename,
+        # return data is mocked to return 'configdata'.
+        cfg.CONF.set_override('config_file', 'irrelevant.yaml',
+                              group='customdns')
+
+        with mock.patch.object(pathlib.Path, 'read_bytes') as \
+                mock_pathlib:
+            mock_pathlib.return_value = configdata
+            cnc = CustomNetworkConfigurator()
+
+        return cnc
+
+    def test_external_yaml_config(self):
+        """Test if the yaml config is converted to the expected internal
+        data structure of our class. Ensures all options are picked up.
+        """
+
+        example_config = b"""
+                matches:
+                    -  domain_name_prefixes:
+                        - ext-abc
+                        - ext-def
+                       project_ids:
+                        - 5dc81c6355ff478188f8fda11a971c41
+                        - 0631d17744fe4a04b16494ae9056ae17
+                       ednslogging: False
+                       upstream_dns_servers:
+                        - 192.0.2.10
+                        - 192.0.2.20
+                    -  domain_name_prefixes:
+                        - ext-abcd
+                        - ext-
+                       ednslogging: True
+                       upstream_dns_servers:
+                        - 192.0.2.30
+                        - 192.0.2.40
+                """
+
+        cnc = self._get_cnc_from_yaml_config(configdata=example_config)
+
+        # CustomNetworkSettings will convert the list of IPs to a set
+        # so we can compare them with ease below.
+        config_1 = CustomNetworkSettings(
+                False, {'192.0.2.10', '192.0.2.20'})
+        config_2 = CustomNetworkSettings(
+                True, {'192.0.2.30', '192.0.2.40'})
+
+        example_config_expected = {
+            'domains': {'ext-': config_2,
+                        'ext-abc': config_1,
+                        'ext-abcd': config_2,
+                        'ext-def': config_1
+                        },
+            'projects': {'0631d17744fe4a04b16494ae9056ae17': config_1,
+                         '5dc81c6355ff478188f8fda11a971c41': config_1
+                         }
+        }
+
+        self.assertEqual(example_config_expected, cnc._dns_config)
+
+    @mock.patch.object(CustomNetworkConfigurator, "_keystone_connection")
+    def test_no_match_no_change_yaml(self, mock_keystone):
+        """ensure that we do not change a setting if the domain does not match
+        """
+
+        # we manipulate the network, so we need fresh mock objects
+        mock_network = {'id': 'net-123', 'project_id': 'p-666'}
+        mock_project = MockedDBObj(id='p-666', domain_id='d-42')
+        mock_domain = MockedDBObj(id='d-42', name='mydomain')
+
+        mock_keystone.get_project.return_value = mock_project
+        mock_keystone.get_domain.return_value = mock_domain
+
+        example_config = b"""
+                matches:
+                    -  domain_name_prefixes:
+                        - ext-abc
+                       project_ids:
+                        - 5dc81c6355ff478188f8fda11a971c41
+                       ednslogging: True
+                       upstream_dns_servers:
+                        - 192.0.2.10
+                        - 192.0.2.20
+                """
+
+        cnc = self._get_cnc_from_yaml_config(configdata=example_config)
+
+        cnc.add_dnssettings_to_net(mock_network)
+
+        mock_keystone.get_project.assert_called_with('p-666')
+        mock_keystone.get_domain.assert_called_with('d-42')
+
+        # assert we do not change the settings
+        self.assertIsNone(mock_network.get('dns_ednslogging_enabled'))
+        self.assertIsNone(mock_network.get('dns_custom_upstreams'))
+
     @mock.patch.object(CustomNetworkConfigurator, "_keystone_connection")
     def test_no_match_no_change(self, mock_keystone):
         """ensure that we do not change a setting if the domain does not match
         """
+        # TODO(mutax): remove this test after migration to new config file
 
         # we manipulate the network, so we need fresh mock objects
         mock_network = {'id': 123, 'project_id': 666}
@@ -88,10 +229,44 @@ class TestDhcpRpcCustomNetworkConfigurator(base.BaseTestCase):
         self.assertIsNone(mock_network.get('dns_custom_upstreams'))
 
     @mock.patch.object(CustomNetworkConfigurator, "_keystone_connection")
+    def test_network_id_lookup_yaml(self, mock_keystone):
+        """ensure keystone lookup methods are called and the network
+           returned matches the expected settings
+        """
+
+        # we manipulate the network, so we need fresh mock objects
+        mock_network = {'id': 'net-123', 'project_id': 'p-666'}
+        mock_project = MockedDBObj(id='p-666', domain_id='d-42')
+        mock_domain = MockedDBObj(id='d-42', name='mydomain')
+
+        mock_keystone.get_project.return_value = mock_project
+        mock_keystone.get_domain.return_value = mock_domain
+
+        example_config = b"""
+                matches:
+                    -  domain_name_prefixes:
+                        - mydomain
+                       ednslogging: False
+                """
+
+        cnc = self._get_cnc_from_yaml_config(configdata=example_config)
+
+        cnc.add_dnssettings_to_net(mock_network)
+
+        mock_keystone.get_project.assert_called_with('p-666')
+        mock_keystone.get_domain.assert_called_with('d-42')
+
+        # assert we get the correct settings when no nameservers are set
+        # but logging should be off
+        self.assertFalse(mock_network.get('dns_ednslogging_enabled'))
+        self.assertIsNone(mock_network.get('dns_custom_upstreams'))
+
+    @mock.patch.object(CustomNetworkConfigurator, "_keystone_connection")
     def test_network_id_lookup(self, mock_keystone):
         """ensure keystone lookup methods are called and the network
            returned matches the expected settings
         """
+        # TODO(mutax): remove this test after migration to new config file
 
         # we manipulate the network, so we need fresh mock objects
         mock_network = {'id': 123, 'project_id': 666}
@@ -119,10 +294,50 @@ class TestDhcpRpcCustomNetworkConfigurator(base.BaseTestCase):
         self.assertIsNone(mock_network.get('dns_custom_upstreams'))
 
     @mock.patch.object(CustomNetworkConfigurator, "_keystone_connection")
+    def test_nameserver_settings_yaml(self, mock_keystone):
+        """ensure the configured nameserver IPs are present in the network
+           dict returned
+        """
+
+        # we manipulate the network, so we need fresh mock objects
+        mock_network = {'id': 'net-123', 'project_id': 'p-666'}
+        mock_project = MockedDBObj(id='p-666', domain_id='d-42')
+        mock_domain = MockedDBObj(id='d-42', name='mydomain')
+
+        mock_keystone.get_project.return_value = mock_project
+        mock_keystone.get_domain.return_value = mock_domain
+
+        dns1 = "2001:db8::456"
+        dns2 = "192.0.2.123"
+
+        example_config = b"""
+                   matches:
+                       -  domain_name_prefixes:
+                           - mydomain
+                          upstream_dns_servers:
+                           - %s
+                           - %s
+                          ednslogging: False
+                   """ % (dns1.encode(), dns2.encode())
+
+        cnc = self._get_cnc_from_yaml_config(configdata=example_config)
+
+        cnc.add_dnssettings_to_net(mock_network)
+        self.assertFalse(mock_network.get('dns_ednslogging_enabled'))
+        sentinel = object()
+        upstreams = mock_network.get('dns_custom_upstreams', sentinel)
+        self.assertNotEqual(sentinel, upstreams)
+        self.assertIsNotNone(upstreams)
+        self.assertIn(dns1, upstreams)
+        self.assertIn(dns2, upstreams)
+        self.assertEqual(len(upstreams), 2)
+
+    @mock.patch.object(CustomNetworkConfigurator, "_keystone_connection")
     def test_nameserver_settings(self, mock_keystone):
         """ensure the configured nameserver IPs are present in the network
            dict returned
         """
+        # TODO(mutax): remove this test after migration to new config file
 
         # we manipulate the network, so we need fresh mock objects
         mock_network = {'id': 123, 'project_id': 666}
@@ -155,8 +370,53 @@ class TestDhcpRpcCustomNetworkConfigurator(base.BaseTestCase):
         self.assertEqual(len(upstreams), 2)
 
     @mock.patch.object(CustomNetworkConfigurator, "_keystone_connection")
-    def test_exceptions_prefixmatch(self, mock_keystone):
+    def test_longest_domain_prefix_wins_yaml(self, mock_keystone):
+        """ensure we are doing a longest prefix match on the domain name,
+        that is if a match 'ext-123' and 'ext-' is present, a domain named
+        'ext-1234' will match the settings for 'ext-123' and not 'ext-'.
+        """
+
+        # we manipulate the network, so we need fresh mock objects
+        mock_network = {'id': 'net-123', 'project_id': 'p-666'}
+        mock_project = MockedDBObj(id='p-666', domain_id='d-42')
+        mock_domain = MockedDBObj(id='d-42', name='mydomain-123')
+
+        mock_keystone.get_project.return_value = mock_project
+        mock_keystone.get_domain.return_value = mock_domain
+
+        dns1 = "2001:db8::456"
+        dns2 = "192.0.2.123"
+
+        example_config = b"""
+                   matches:
+                       -  domain_name_prefixes:
+                           - mydo
+                          upstream_dns_servers:
+                           - 192.0.2.222
+                           - 192.0.2.111
+                          ednslogging: True
+                       -  domain_name_prefixes:
+                           - mydomain-
+                          upstream_dns_servers:
+                           - %s
+                           - %s
+                          ednslogging: False
+                   """ % (dns1.encode(), dns2.encode())
+
+        cnc = self._get_cnc_from_yaml_config(configdata=example_config)
+
+        cnc.add_dnssettings_to_net(mock_network)
+
+        self.assertFalse(mock_network.get('dns_ednslogging_enabled'))
+
+        upstreams = mock_network.get('dns_custom_upstreams')
+        self.assertIn(dns1, upstreams)
+        self.assertIn(dns2, upstreams)
+
+    @mock.patch.object(CustomNetworkConfigurator, "_keystone_connection")
+    def test_longest_domain_prefix_wins(self, mock_keystone):
         """ensure we are doing a prefix match on the domain name """
+        # TODO(mutax): remove this test after migration to new config file
 
         # we manipulate the network, so we need fresh mock objects
         mock_network = {'id': 123, 'project_id': 666}
@@ -187,10 +447,44 @@ class TestDhcpRpcCustomNetworkConfigurator(base.BaseTestCase):
         self.assertIn(dns2, upstreams)
 
     @mock.patch.object(CustomNetworkConfigurator, "_keystone_connection")
-    def test_exceptions_catched_project_lookup(self, mock_keystone):
+    def test_project_lookup_exceptions_dont_prevent_netconf_yaml(
+            self,
+            mock_keystone):
+        """ensure that all exceptions are catched and do not break the
+           rpc call when doing the project lookup
+        """
+
+        # we manipulate the network, so we need fresh mock objects
+        mock_network = {'id': 'net-123', 'project_id': 'p-666'}
+        mock_domain = MockedDBObj(id='d-42', name='mydomain-123')
+
+        mock_keystone.get_project.side_effect = Exception('Test')
+        mock_keystone.get_domain.return_value = mock_domain
+
+        example_config = b"""
+                   matches:
+                       -  domain_name_prefixes:
+                           - mydomain-
+                          upstream_dns_servers:
+                           - 2001:db8::456
+                           - 192.0.2.123
+                          ednslogging: False
+                   """
+
+        cnc = self._get_cnc_from_yaml_config(configdata=example_config)
+
+        cnc.add_dnssettings_to_net(mock_network)
+        upstreams = mock_network.get('dns_custom_upstreams')
+        self.assertIsNone(upstreams)
+
+    @mock.patch.object(CustomNetworkConfigurator, "_keystone_connection")
+    def test_project_lookup_exceptions_do_not_prevent_netconfig(
+            self,
+            mock_keystone):
         """ensure that all exceptions are catched and do not break the
            rpc call
         """
+        # TODO(mutax): remove this test after migration to new config file
 
         # we manipulate the network, so we need fresh mock objects
         mock_network = {'id': 123, 'project_id': 666}
@@ -211,10 +505,44 @@ class TestDhcpRpcCustomNetworkConfigurator(base.BaseTestCase):
         self.assertIsNone(upstreams)
 
     @mock.patch.object(CustomNetworkConfigurator, "_keystone_connection")
-    def test_exceptions_catched_domain_lookup(self, mock_keystone):
+    def test_domain_lookup_exceptions_do_not_prevent_netconfig_yaml(
+            self,
+            mock_keystone):
+        """ensure that all exceptions are catched and do not break the
+           rpc call when doing the domain lookup
+        """
+
+        # we manipulate the network, so we need fresh mock objects
+        mock_network = {'id': 'net-123', 'project_id': 'p-666'}
+        mock_project = MockedDBObj(id='p-666', domain_id='d-42')
+
+        mock_keystone.get_project.return_value = mock_project
+        mock_keystone.get_domain.side_effect = Exception('Test')
+
+        example_config = b"""
+                   matches:
+                       -  domain_name_prefixes:
+                           - mydomain
+                          upstream_dns_servers:
+                           - 2001:db8::456
+                           - 192.0.2.123
+                          ednslogging: False
+                   """
+
+        cnc = self._get_cnc_from_yaml_config(configdata=example_config)
+
+        cnc.add_dnssettings_to_net(mock_network)
+        upstreams = mock_network.get('dns_custom_upstreams')
+        self.assertIsNone(upstreams)
+
+    @mock.patch.object(CustomNetworkConfigurator, "_keystone_connection")
+    def test_domain_lookup_exceptions_do_not_prevent_netconfig(
+            self,
+            mock_keystone):
         """ensure that all exceptions are catched and do not break the
            rpc call
         """
+        # TODO(mutax): remove this test after migration to new config file
 
         # we manipulate the network, so we need fresh mock objects
         mock_network = {'id': 123, 'project_id': 666}
@@ -233,6 +561,67 @@ class TestDhcpRpcCustomNetworkConfigurator(base.BaseTestCase):
         cnc.add_dnssettings_to_net(mock_network)
         upstreams = mock_network.get('dns_custom_upstreams')
         self.assertIsNone(upstreams)
+
+    @mock.patch.object(CustomNetworkConfigurator, "_keystone_connection")
+    def test_network_ednslogging_setting_yaml(self, mock_keystone):
+        """ensure the networks can be configured with or without edns logging
+        """
+
+        # we manipulate the network, so we need fresh mock objects
+        mock_network_nologging = {'id': 'net-nolog-123', 'project_id': 'p-666'}
+        mock_network_logging = {'id': 'net-log-456', 'project_id': 'p-667'}
+
+        example_config = b"""
+                matches:
+                    -  project_ids:
+                        - p-666
+                       ednslogging: False
+                    -  project_ids:
+                        - p-667
+                       ednslogging: True
+                """
+
+        cnc = self._get_cnc_from_yaml_config(configdata=example_config)
+
+        cnc.add_dnssettings_to_net(mock_network_nologging)
+        cnc.add_dnssettings_to_net(mock_network_logging)
+
+        # assert we get the correct settings when no nameservers are set
+        # but logging is configured accordingly
+        self.assertFalse(mock_network_nologging.get('dns_ednslogging_enabled'))
+        self.assertTrue(mock_network_logging.get('dns_ednslogging_enabled'))
+
+        self.assertIsNone(mock_network_nologging.get('dns_custom_upstreams'))
+        self.assertIsNone(mock_network_logging.get('dns_custom_upstreams'))
+
+    def test_exceptions_configerror_types_yaml(self):
+        """ensure we are catching non-ip entries
+        """
+
+        example_config = b"""
+                   matches:
+                       -  project_ids:
+                           - p-666
+                          upstream_dns_servers:
+                           - not-an-ip-address
+                          ednslogging: False
+                   """
+
+        try:
+            self._get_cnc_from_yaml_config(configdata=example_config)
+        except CustomNetworkConfigError as e:
+            self.assertIn('not-an-ip-address', str(e))
+
+        example_config = b"""
+                   matches:
+                       -  project_ids:
+                           - p-666
+                          ednslogging: NotABoolean
+                   """
+        try:
+            self._get_cnc_from_yaml_config(configdata=example_config)
+        except CustomNetworkConfigError as e:
+            self.assertIn('NotABoolean', str(e))
 
 
 class TestDhcpRpcCallback(base.BaseTestCase):

--- a/requirements.txt
+++ b/requirements.txt
@@ -59,3 +59,5 @@ os-vif>=3.1.0 # Apache-2.0
 futurist>=1.2.0 # Apache-2.0
 tooz>=1.58.0 # Apache-2.0
 wmi>=1.4.9;sys_platform=='win32'  # MIT
+
+PyYAML>=6.0.1 # MIT


### PR DESCRIPTION
We already allow configuration of custom upstream DNS servers for
dnsmasq, based on the OpenStack domain or -- for testing -- based on
the project-id.

We currently can configure only two sets of DNS upstream servers:
One for SAP OpenStack domains and one for external OpenStack domains.
For exteral domains we also always disable the edns and umbrella logging
options in dnsmasq.

Now the requirement arose to configure DNS servers individually on a
per-domain basis and also to be able to enable logging individually.

They requirements now are:

- use default DNS servers and enable logging when no config is set
- enable logging and custom upstreams for specific domains individually
- allow fallback for domains matching a certain prefix to use a
  different default set of resolvers and setting for logging.

This is achieved via a new configuration setting 'config_file' in the
customdns section of neutron.conf that points to a yaml file.

This file allows setting logging and upstream dns settings as follows:

```yaml
matches:
  - domain_name_prefixes:
      - external-abc
    project_ids:
      - 5dc81c6355ff478188f8fda11a971c41
    upstream_dns_servers:
      - 192.0.2.10
      - 192.0.2.20
    ednslogging: True
  - domain_name_prefixes:
      - external-abcd
      - external-
    upstream_dns_servers:
      - 192.0.2.30
      - 192.0.2.40
    ednslogging: False
```

related:
- https://github.com/sapcc/neutron/commit/f39dccefdddeb4aa2ff990111c9849c3ca574cc6
- https://github.com/sapcc/neutron/commit/f186f86a680ff78a044657f4791260e8189b77a9
- https://github.com/sapcc/neutron/commit/c4bdb2973ff4a21078842d44d23d39163059add7
