### PR TITLE
[customdns] removing customdns configuration via neutron config file

### DIFF
--- a/neutron/api/rpc/handlers/dhcp_rpc.py
+++ b/neutron/api/rpc/handlers/dhcp_rpc.py
@@ -75,30 +75,38 @@ class CustomNetworkSettings:
     dns_custom_upstreams: set[str] | None = None
 
     def __post_init__(self):
+
         if not isinstance(self.dns_ednslogging_enabled, bool):
             raise TypeError(_("dns_ednslogging_enabled must be a bool: %s")
                             % self.dns_ednslogging_enabled)
-        if self.dns_custom_upstreams:
-            self._validate_upstreams()
 
-    def _validate_upstreams(self):
+        if self.dns_custom_upstreams:
+            try:
+                self.dns_custom_upstreams = self._validate_ip_addresses(
+                    self.dns_custom_upstreams)
+            except ValueError as e:
+                LOG.error("Invalid DNS server list: %s", e)
+                raise
+
+    @staticmethod
+    def _validate_ip_addresses(addresses: set[str] | None) -> set[str]:
         """ensure that all elements are valid IP addresses and make it a
         set of strings containing the normalized IP addresses.
         """
-        if not self.dns_custom_upstreams:
-            self.dns_custom_upstreams = set()
-            return
 
-        addrs: set[str] = set()
-        for item in self.dns_custom_upstreams:
+        if not addresses:
+            return set()
+
+        validated: set[str] = set()
+        for item in addresses:
             try:
                 addr = ipaddress.ip_address(item)
-                addrs.add(addr.compressed)
+                validated.add(addr.compressed)
             except ValueError:
-                LOG.error("not a valid IP for DNS entry: %s", item)
+                LOG.error("not a valid IP address: %s", item)
                 raise
 
-        self.dns_custom_upstreams = addrs
+        return validated
 
 
 class CustomNetworkConfigurator:
@@ -115,8 +123,8 @@ class CustomNetworkConfigurator:
         """load or reload custom dns config from file."""
 
         if not self._config_file:
-            # option is empty or not set
-            return
+            raise CustomNetworkConfigError(_("no config_file set but custom "
+                                             "network config requested"))
 
         LOG.debug("loading customdns config from '%s'", self._config_file)
 
@@ -150,7 +158,7 @@ class CustomNetworkConfigurator:
         valid_keys = mandatory_keys | {
                       'project_ids',
                       'domain_name_prefixes',
-                      'upstream_dns_servers'
+                      'upstream_dns_servers',
                     }
 
         for item in matches:
@@ -206,23 +214,8 @@ class CustomNetworkConfigurator:
         self._dns_config = dns_config
 
     def add_dnssettings_to_net(self, network_dict):
-        """Add custom dns settings to the network if the network
-        is found to be part of one of the custom OpenStack domains
-        or projects from our settings.
-        """
-
-        # TODO(mutax): after migration replace this whole method with
-        #              the method '_add_external_dnssettings_to_net'
-
-        # check if we got an external custom dns config
-        if self._dns_config:
-            self._add_external_dnssettings_to_net(network_dict)
-        else:
-            self._add_legacy_dnssettings_to_net(network_dict)
-
-    def _add_external_dnssettings_to_net(self, network_dict):
         """Add custom dns settings specified via external config file
-        to the network, if the network matches the criteria set in the
+        to the network, if the network matches any of the criteria set in the
         config file.
         """
 
@@ -231,49 +224,36 @@ class CustomNetworkConfigurator:
 
         # first check if we have a match in the project ids,
         # this is the cheapest lookup
-        if self._apply_project_settings(network_dict):
-            return
-
-        # next try to match openstack domain name prefixes.
-        self._apply_domain_settings(network_dict)
-
-    def _apply_project_settings(self, network_dict: dict) -> bool:
-        """apply project-specific DNS settings if they exist.
-        Returns True if settings were found to allow skipping of
-        further processing. Not to be called directly.
-        """
-
-        if not self._dns_config:
-            return False
 
         project_id = network_dict['project_id']
 
-        # check if the project-id matches the list for custom settings
         custom_config = self._dns_config['projects'].get(project_id)
         if custom_config:
             LOG.debug("setting custom settings for net %s, "
                       "project %s matches: %s",
                       network_dict['id'], project_id, custom_config
                       )
+        else:
+            # try to match openstack domain name prefixes.
+            custom_config = self._find_domain_settings(network_dict)
 
-            network_dict['dns_ednslogging_enabled'] = (
-                custom_config.dns_ednslogging_enabled)
+        if not custom_config:
+            return
 
-            if custom_config.dns_custom_upstreams:
-                network_dict['dns_custom_upstreams'] = (
-                    custom_config.dns_custom_upstreams)
-            return True
+        network_dict['dns_ednslogging_enabled'] = (
+            custom_config.dns_ednslogging_enabled)
 
-        return False
+        if custom_config.dns_custom_upstreams:
+            network_dict['dns_custom_upstreams'] = (
+                custom_config.dns_custom_upstreams)
 
-    def _apply_domain_settings(self, network_dict: dict) -> bool:
-        """apply domain-specific DNS settings if they exist.
-        Returns True if settings were found to allow skipping of
-        further processing for consistency. Not to be called directly.
+    def _find_domain_settings(self, network_dict: dict) -> (
+            CustomNetworkSettings | None):
+        """lookup domain-specific DNS settings if they exist.
         """
 
         if not self._dns_config:
-            return False
+            return None
 
         # try to retrieve the OpenStack domain name via the project id,
         # this uses a local cache and on a cache miss queries keystone
@@ -301,7 +281,7 @@ class CustomNetworkConfigurator:
             LOG.warning('Unable to retrieve domain name for project %s,'
                         ' falling back to default settings for network %s',
                         project_id, network_dict['id'])
-            return False
+            return None
 
         # check if the OpenStack domain name starts with one of the prefixes
         # from our config (or is equal).
@@ -322,59 +302,9 @@ class CustomNetworkConfigurator:
                           domain_prefix, custom_config
                           )
 
-                network_dict['dns_ednslogging_enabled'] = (
-                    custom_config.dns_ednslogging_enabled)
+                return custom_config
 
-                if custom_config.dns_custom_upstreams:
-                    network_dict['dns_custom_upstreams'] = (
-                        custom_config.dns_custom_upstreams)
-                return True
-        return False
-
-    def _add_legacy_dnssettings_to_net(self, network_dict):
-        """If the network domain or project match the configured list,
-        apply custom dns servers to the configuration.
-        Legacy method to be removed after deployment of the new config files.
-        """
-        # TODO(mutax): remove this method after migration to new config file
-
-        if not (cfg.CONF.customdns.domain_name_prefixes or
-                cfg.CONF.customdns.project_ids):
-            # The config is empty, there is no need to do any lookups
-            # against keystone
-            return
-
-        if not self._is_customdns_network(network_dict):
-            return
-
-        # logging always has to be disabled for all custom domains
-        network_dict['dns_ednslogging_enabled'] = False
-
-        if cfg.CONF.customdns.upstream_dns_servers:
-            # only set if the config setting isn't empty, so we do not
-            # break DNS resolution in that domain when the config is
-            # incomplete. Can also be used intentionally to only disable
-            # logging but keep the default upstream servers.
-            addrs = []
-            # TODO(mutax): make e.g. custom config item type to validate only
-            #  once on startup
-            for item in cfg.CONF.customdns.upstream_dns_servers:
-                try:
-                    addr = ipaddress.ip_address(item)
-                    addrs.append(addr.compressed)
-                except ValueError:
-                    LOG.error("Custom DNS settings invalid for network %s "
-                              "not a valid IP for DNS: %s",
-                              network_dict['id'], item)
-            network_dict['dns_custom_upstreams'] = addrs
-
-        LOG.debug("Network %s is in a custom OS-domain, "
-                 "customized DNS settings: "
-                 "dns_ednslogging_enabled=%s, "
-                 "dns_custom_upstreams=%s",
-                 network_dict['id'],
-                 network_dict.get('dns_ednslogging_enabled', 'NOT-SET'),
-                 network_dict.get('dns_custom_upstreams', 'NOT-SET'))
+        return None
 
     @property
     def _keystone_connection(self):
@@ -446,59 +376,6 @@ class CustomNetworkConfigurator:
             self._domain_name_cache[domain_id] = domain_name
 
         return domain_name
-
-    def _is_customdns_network(self, network_dict: dict) -> bool:
-        """check if the network is in an OpenStack domain or project that we
-           want to configure in a custom way.
-           For domains we use prefix matches on the name, for projects we
-           directly match on the id.
-        """
-        project_id = network_dict['project_id']
-
-        # TODO(mutax): remove this method after migration to new config file
-
-        # should not happen, but would never match anyway
-        if not project_id:
-            return False
-
-        # check if the project-id matches the list for custom settings
-        if project_id in cfg.CONF.customdns.project_ids:
-            # this comes in handy for testing, no need for a test-domain!
-            LOG.debug("domainlookup: project %s matches customdns project ids",
-                      project_id)
-            return True
-
-        # now try to retrieve the OpenStack domain name via the project id,
-        # this uses a local cache and on a cache miss queries keystone
-        domain_name = None
-        try:
-            domain_name = self.get_domain_name(project_id)
-        except Exception as e:  # noqa
-            # If Keystone is not reachable or something goes wrong with
-            # the lookup, we do not want to fail configuring all networks.
-            # Currently, the sane thing to do is using default settings in
-            # those cases. As we want to fail to the default in all error
-            # cases anyway, we can use a bare Exception here.
-            # TODO(mutax): I do want to get the stack trace logged, but I
-            #   also want to get a nice warning to the log independent of the
-            #   source of the error - but now we log the same error twice.
-            LOG.exception('Failed to retrieve domain to set custom dns for'
-                          ' project %s of network %s - %s: %s',
-                          project_id, network_dict['id'], type(e), e
-                          )
-
-        # in case of an error or empty result, we fall back to the 'safe'
-        # side by using default settings.
-        if not domain_name:
-            LOG.warning('Unable to retrieve domain name for project %s,'
-                        ' falling back to default settings for network %s',
-                        project_id, network_dict['id'])
-            return False
-
-        # check if the OpenStack domain name starts with one of the prefixes
-        # from our config (or is equal).
-        return domain_name.startswith(
-                tuple(cfg.CONF.customdns.domain_name_prefixes))
 
 
 class DhcpRpcCallback(object):

--- a/neutron/conf/service.py
+++ b/neutron/conf/service.py
@@ -60,16 +60,6 @@ DNSSETTINGS_OPTS = [
     cfg.BoolOpt('enabled',
                 default=False,
                 help=_("Enable domain specific DNS settings.")),
-    # TODO(mutax): remove deprecated options after migration to config file
-    cfg.ListOpt('upstream_dns_servers', default=[],
-                help=_("Custom upstream DNS server IPs"
-                       " (deprecated, use config_file)")),
-    cfg.ListOpt('domain_name_prefixes', default=[],
-                help=_("OS Domain Name Prefixes to match against"
-                       " (deprecated, use config_file)")),
-    cfg.ListOpt('project_ids', default=[],
-                help=_("IDs of projects to match for testing only"
-                       " (deprecated, use config_file)")),
     cfg.StrOpt('config_file', default=None,
                help=_("Path to yaml config file for OpenStack domain "
                       "or project specific DNS settings.")

--- a/neutron/tests/unit/api/rpc/handlers/test_dhcp_rpc.py
+++ b/neutron/tests/unit/api/rpc/handlers/test_dhcp_rpc.py
@@ -34,6 +34,7 @@ from neutron.api.rpc.handlers import dhcp_rpc
 from neutron.api.rpc.handlers.dhcp_rpc import CustomNetworkConfigError
 from neutron.api.rpc.handlers.dhcp_rpc import CustomNetworkConfigurator
 from neutron.api.rpc.handlers.dhcp_rpc import CustomNetworkSettings
+from neutron.api.rpc.handlers.dhcp_rpc import DhcpRpcCallback
 from neutron.common import utils
 from neutron.db import provisioning_blocks
 from neutron.objects import network as network_obj
@@ -49,50 +50,6 @@ class MockedDBObj(UserDict):
 
 
 class TestDhcpRpcCustomNetworkConfigurator(base.BaseTestCase):
-
-    def test_network_dict_empty(self):
-        """ensure nothing is added to the network dict when
-           nothing is configured
-        """
-        cnc = CustomNetworkConfigurator()
-
-        empty_dict = {}
-        cnc.add_dnssettings_to_net(empty_dict)
-
-        self.assertFalse(bool(empty_dict))
-
-    @mock.patch.object(pathlib.Path, 'read_bytes')
-    def test_external_yaml_config_parser(self, mock_pathlib):
-        """Basic tests for an empty, invalid or on-purpose empty
-        config file.
-        """
-
-        cfg.CONF.set_override('enabled', True,
-                              group='customdns')
-        # just needs to be set and a valid filename,
-        # return data is mocked above.
-        cfg.CONF.set_override('config_file', 'irrelevant.yaml',
-                              group='customdns')
-
-        empty_config = b""
-
-        mock_pathlib.return_value = empty_config
-        self.assertRaises(CustomNetworkConfigError, CustomNetworkConfigurator)
-
-        invalid_config = b"""
-                          foobar:
-                        """
-
-        mock_pathlib.return_value = invalid_config
-        self.assertRaises(CustomNetworkConfigError, CustomNetworkConfigurator)
-
-        no_config = b"""
-                     matches:
-                    """
-
-        mock_pathlib.return_value = no_config
-        cnc = CustomNetworkConfigurator()
-        self.assertEqual({}, cnc._dns_config)
 
     def _get_cnc_from_yaml_config(self, configdata: bytes)\
             -> CustomNetworkConfigurator:
@@ -114,7 +71,144 @@ class TestDhcpRpcCustomNetworkConfigurator(base.BaseTestCase):
 
         return cnc
 
-    def test_external_yaml_config(self):
+    def test_network_dict_empty(self):
+        """Ensure nothing is added to the network dict when
+        nothing is configured.
+        """
+        cfg.CONF.set_override('enabled', True,
+                              group='customdns')
+        cfg.CONF.set_override('config_file', 'irrelevant.yaml',
+                              group='customdns')
+
+        with mock.patch.object(pathlib.Path, 'read_bytes') as \
+                mock_pathlib:
+
+            mock_pathlib.return_value = b"matches:\n"
+            cnc = CustomNetworkConfigurator()
+            mock_pathlib.assert_called_once()
+
+            empty_dict = {}
+            cnc.add_dnssettings_to_net(empty_dict)
+            self.assertFalse(bool(empty_dict))
+
+    def test_ensure_config_not_read_if_not_enabled(self):
+        """Ensure that we do not try to load the config file and there is no
+        CustomNetworkConfigurator instance created, when the feature is not
+        enabled.
+        """
+        cfg.CONF.set_override('enabled', False,
+                              group='customdns')
+        cfg.CONF.set_override('config_file', 'mock_did_not_work.yaml',
+                              group='customdns')
+
+        with mock.patch.object(pathlib.Path, 'read_bytes') as \
+                mock_pathlib:
+            msg = "[Errno 2] No such file or directory: 'mock_was_called.yaml'"
+            mock_pathlib.side_effect = FileNotFoundError(msg)
+            rpc_callback = DhcpRpcCallback()
+
+        mock_pathlib.assert_not_called()
+        self.assertIsNone(rpc_callback._config_lookup)
+
+    def test_ensure_config_file_is_required_if_enabled(self):
+        """Ensure that if the feature is enabled but the file cannot be found
+           we raise an exception when trying to start and trying to create
+           an instance of DhcpRpcCallback.
+        """
+        cfg.CONF.set_override('enabled', True,
+                              group='customdns')
+        cfg.CONF.set_override('config_file', 'mock_did_not_work.yaml',
+                              group='customdns')
+
+        # DhcpRpcCallback will try to create a CustomNetworkConfigurator
+        # which should trigger the exception:
+        with mock.patch.object(pathlib.Path, 'read_bytes') as \
+                mock_pathlib:
+            msg = "[Errno 2] No such file or directory: 'mock_was_called.yaml'"
+            mock_pathlib.side_effect = FileNotFoundError(msg)
+            self.assertRaises(CustomNetworkConfigError,
+                              DhcpRpcCallback)
+            mock_pathlib.assert_called_once()
+
+    def test_ensure_config_enabled_flag_ignored_by_configurator(self):
+        """Ensure that if the feature is disabled, we still can instanciate
+        a CustomNetworkConfigurator.
+        """
+        cfg.CONF.set_override('enabled', False,
+                              group='customdns')
+        cfg.CONF.set_override('config_file', 'mock_did_not_work.yaml',
+                              group='customdns')
+
+        # CustomNetworkConfigurator will try to load the config file
+        # with enabled=False because the flag triggers the overall feature
+        # only and the config parser/config helper should not be too closely
+        # coupled here.
+        with mock.patch.object(pathlib.Path, 'read_bytes') as \
+                mock_pathlib:
+
+            mock_pathlib.return_value = b"matches:\n"
+            cnc = CustomNetworkConfigurator()
+            mock_pathlib.assert_called_once()
+            self.assertEqual({}, cnc._dns_config)
+
+    def test_ensure_config_enabled_requires_valid_configfile(self):
+        """Ensure that if the feature is enabled, we require a valid
+        configuration file.
+        """
+        cfg.CONF.set_override('enabled', True,
+                              group='customdns')
+        cfg.CONF.set_override('config_file', None,
+                              group='customdns')
+
+        with mock.patch.object(pathlib.Path, 'read_bytes') as \
+                mock_pathlib:
+            msg = "[Errno 2] No such file or directory: 'mock_was_called.yaml'"
+            mock_pathlib.side_effect = FileNotFoundError(msg)
+            self.assertRaises(CustomNetworkConfigError,
+                              DhcpRpcCallback)
+            mock_pathlib.assert_not_called()
+
+    def test_yaml_config_parser(self):
+        """Basic tests for an empty, invalid or on-purpose empty
+        config file.
+        """
+
+        cfg.CONF.set_override('enabled', True,
+                              group='customdns')
+        # just needs to be set and a valid filename,
+        # returned data is mocked.
+        cfg.CONF.set_override('config_file', 'irrelevant.yaml',
+                              group='customdns')
+
+        # we do not allow an empty file as valid config
+        empty_config = b""
+        with mock.patch.object(pathlib.Path, 'read_bytes') as \
+                mock_pathlib:
+            mock_pathlib.return_value = empty_config
+            self.assertRaises(CustomNetworkConfigError,
+                              CustomNetworkConfigurator)
+
+        # we do not allow a file that has no metrics: key as valid config
+        invalid_config = b"""
+                          foobar:
+                        """
+        with mock.patch.object(pathlib.Path, 'read_bytes') as \
+                mock_pathlib:
+            mock_pathlib.return_value = invalid_config
+            self.assertRaises(CustomNetworkConfigError,
+                              CustomNetworkConfigurator)
+
+        # we _do_ allow a config with an on-purpose empty ruleset
+        no_config = b"""
+                     matches:
+                    """
+        with mock.patch.object(pathlib.Path, 'read_bytes') as \
+                mock_pathlib:
+            mock_pathlib.return_value = no_config
+            cnc = CustomNetworkConfigurator()
+            self.assertEqual({}, cnc._dns_config)
+
+    def test_yaml_config_loader(self):
         """Test if the yaml config is converted to the expected internal
         data structure of our class. Ensures all options are picked up.
         """
@@ -163,8 +257,9 @@ class TestDhcpRpcCustomNetworkConfigurator(base.BaseTestCase):
         self.assertEqual(example_config_expected, cnc._dns_config)
 
     @mock.patch.object(CustomNetworkConfigurator, "_keystone_connection")
-    def test_no_match_no_change_yaml(self, mock_keystone):
-        """ensure that we do not change a setting if the domain does not match
+    def test_no_match_no_change(self, mock_keystone):
+        """ensure that we do not change a network setting if the domain
+         and project do not match the ones in the config
         """
 
         # we manipulate the network, so we need fresh mock objects
@@ -199,37 +294,7 @@ class TestDhcpRpcCustomNetworkConfigurator(base.BaseTestCase):
         self.assertIsNone(mock_network.get('dns_custom_upstreams'))
 
     @mock.patch.object(CustomNetworkConfigurator, "_keystone_connection")
-    def test_no_match_no_change(self, mock_keystone):
-        """ensure that we do not change a setting if the domain does not match
-        """
-        # TODO(mutax): remove this test after migration to new config file
-
-        # we manipulate the network, so we need fresh mock objects
-        mock_network = {'id': 123, 'project_id': 666}
-        mock_project = MockedDBObj(id=666, domain_id=42)
-        mock_domain = MockedDBObj(id=42, name='mydomain')
-
-        mock_keystone.get_project.return_value = mock_project
-        mock_keystone.get_domain.return_value = mock_domain
-
-        cfg.CONF.set_override('enabled', True,
-                              group='customdns')
-        cfg.CONF.set_override('domain_name_prefixes', ['some', 'other'],
-                              group='customdns')
-
-        cnc = CustomNetworkConfigurator()
-
-        cnc.add_dnssettings_to_net(mock_network)
-
-        mock_keystone.get_project.assert_called_with(666)
-        mock_keystone.get_domain.assert_called_with(42)
-
-        # assert we do not change the settings
-        self.assertIsNone(mock_network.get('dns_ednslogging_enabled'))
-        self.assertIsNone(mock_network.get('dns_custom_upstreams'))
-
-    @mock.patch.object(CustomNetworkConfigurator, "_keystone_connection")
-    def test_network_id_lookup_yaml(self, mock_keystone):
+    def test_network_id_lookup(self, mock_keystone):
         """ensure keystone lookup methods are called and the network
            returned matches the expected settings
         """
@@ -262,41 +327,9 @@ class TestDhcpRpcCustomNetworkConfigurator(base.BaseTestCase):
         self.assertIsNone(mock_network.get('dns_custom_upstreams'))
 
     @mock.patch.object(CustomNetworkConfigurator, "_keystone_connection")
-    def test_network_id_lookup(self, mock_keystone):
-        """ensure keystone lookup methods are called and the network
-           returned matches the expected settings
-        """
-        # TODO(mutax): remove this test after migration to new config file
-
-        # we manipulate the network, so we need fresh mock objects
-        mock_network = {'id': 123, 'project_id': 666}
-        mock_project = MockedDBObj(id=666, domain_id=42)
-        mock_domain = MockedDBObj(id=42, name='mydomain')
-
-        mock_keystone.get_project.return_value = mock_project
-        mock_keystone.get_domain.return_value = mock_domain
-
-        cfg.CONF.set_override('enabled', True,
-                              group='customdns')
-        cfg.CONF.set_override('domain_name_prefixes', ['mydomain'],
-                              group='customdns')
-
-        cnc = CustomNetworkConfigurator()
-
-        cnc.add_dnssettings_to_net(mock_network)
-
-        mock_keystone.get_project.assert_called_with(666)
-        mock_keystone.get_domain.assert_called_with(42)
-
-        # assert we get the correct settings when no nameservers are set
-        # but logging should be off
-        self.assertFalse(mock_network.get('dns_ednslogging_enabled'))
-        self.assertIsNone(mock_network.get('dns_custom_upstreams'))
-
-    @mock.patch.object(CustomNetworkConfigurator, "_keystone_connection")
-    def test_nameserver_settings_yaml(self, mock_keystone):
-        """ensure the configured nameserver IPs are present in the network
-           dict returned
+    def test_nameserver_settings_applied(self, mock_keystone):
+        """ensure that if the domain of a network matched, the configured
+           nameserver IPs are present in the network dict returned
         """
 
         # we manipulate the network, so we need fresh mock objects
@@ -333,47 +366,12 @@ class TestDhcpRpcCustomNetworkConfigurator(base.BaseTestCase):
         self.assertEqual(len(upstreams), 2)
 
     @mock.patch.object(CustomNetworkConfigurator, "_keystone_connection")
-    def test_nameserver_settings(self, mock_keystone):
-        """ensure the configured nameserver IPs are present in the network
-           dict returned
-        """
-        # TODO(mutax): remove this test after migration to new config file
-
-        # we manipulate the network, so we need fresh mock objects
-        mock_network = {'id': 123, 'project_id': 666}
-        mock_project = MockedDBObj(id=666, domain_id=42)
-        mock_domain = MockedDBObj(id=42, name='mydomain')
-
-        mock_keystone.get_project.return_value = mock_project
-        mock_keystone.get_domain.return_value = mock_domain
-
-        dns1 = "2001:db8::456"
-        dns2 = "192.0.2.123"
-
-        cfg.CONF.set_override('enabled', True,
-                              group='customdns')
-        cfg.CONF.set_override('domain_name_prefixes', ['mydomain'],
-                              group='customdns')
-        cfg.CONF.set_override('upstream_dns_servers', [dns1, dns2],
-                              group='customdns')
-
-        cnc = CustomNetworkConfigurator()
-
-        cnc.add_dnssettings_to_net(mock_network)
-        self.assertFalse(mock_network.get('dns_ednslogging_enabled'))
-        sentinel = object()
-        upstreams = mock_network.get('dns_custom_upstreams', sentinel)
-        self.assertNotEqual(sentinel, upstreams)
-        self.assertIsNotNone(upstreams)
-        self.assertIn(dns1, upstreams)
-        self.assertIn(dns2, upstreams)
-        self.assertEqual(len(upstreams), 2)
-
-    @mock.patch.object(CustomNetworkConfigurator, "_keystone_connection")
-    def test_longest_domain_prefix_wins_yaml(self, mock_keystone):
+    def test_longest_domain_prefix_wins(self, mock_keystone):
         """ensure we are doing a longest prefix match on the domain name,
         that is if a match 'ext-123' and 'ext-' is present, a domain named
         'ext-1234' will match the settings for 'ext-123' and not 'ext-'.
+
+        This allows configuration of a fallback for all "ext-*" domains.
         """
 
         # we manipulate the network, so we need fresh mock objects
@@ -414,40 +412,7 @@ class TestDhcpRpcCustomNetworkConfigurator(base.BaseTestCase):
         self.assertIn(dns2, upstreams)
 
     @mock.patch.object(CustomNetworkConfigurator, "_keystone_connection")
-    def test_longest_domain_prefix_wins(self, mock_keystone):
-        """ensure we are doing a prefix match on the domain name """
-        # TODO(mutax): remove this test after migration to new config file
-
-        # we manipulate the network, so we need fresh mock objects
-        mock_network = {'id': 123, 'project_id': 666}
-        mock_project = MockedDBObj(id=666, domain_id=42)
-        mock_domain = MockedDBObj(id=42, name='mydomain-123')
-
-        mock_keystone.get_project.return_value = mock_project
-        mock_keystone.get_domain.return_value = mock_domain
-
-        dns1 = "2001:db8::456"
-        dns2 = "192.0.2.123"
-
-        cfg.CONF.set_override('enabled', True,
-                              group='customdns')
-        cfg.CONF.set_override('domain_name_prefixes', ['mydomain'],
-                              group='customdns')
-        cfg.CONF.set_override('upstream_dns_servers', [dns1, dns2],
-                              group='customdns')
-
-        cnc = CustomNetworkConfigurator()
-
-        cnc.add_dnssettings_to_net(mock_network)
-
-        self.assertFalse(mock_network.get('dns_ednslogging_enabled'))
-
-        upstreams = mock_network.get('dns_custom_upstreams')
-        self.assertIn(dns1, upstreams)
-        self.assertIn(dns2, upstreams)
-
-    @mock.patch.object(CustomNetworkConfigurator, "_keystone_connection")
-    def test_project_lookup_exceptions_dont_prevent_netconf_yaml(
+    def test_project_lookup_exceptions_dont_prevent_netconf(
             self,
             mock_keystone):
         """ensure that all exceptions are catched and do not break the
@@ -478,34 +443,7 @@ class TestDhcpRpcCustomNetworkConfigurator(base.BaseTestCase):
         self.assertIsNone(upstreams)
 
     @mock.patch.object(CustomNetworkConfigurator, "_keystone_connection")
-    def test_project_lookup_exceptions_do_not_prevent_netconfig(
-            self,
-            mock_keystone):
-        """ensure that all exceptions are catched and do not break the
-           rpc call
-        """
-        # TODO(mutax): remove this test after migration to new config file
-
-        # we manipulate the network, so we need fresh mock objects
-        mock_network = {'id': 123, 'project_id': 666}
-        mock_domain = MockedDBObj(id=42, name='mydomain-123')
-
-        mock_keystone.get_project.side_effect = Exception('Test')
-        mock_keystone.get_domain.return_value = mock_domain
-
-        cfg.CONF.set_override('enabled', True,
-                              group='customdns')
-        cfg.CONF.set_override('domain_name_prefixes', ['mydomain'],
-                              group='customdns')
-
-        cnc = CustomNetworkConfigurator()
-
-        cnc.add_dnssettings_to_net(mock_network)
-        upstreams = mock_network.get('dns_custom_upstreams')
-        self.assertIsNone(upstreams)
-
-    @mock.patch.object(CustomNetworkConfigurator, "_keystone_connection")
-    def test_domain_lookup_exceptions_do_not_prevent_netconfig_yaml(
+    def test_domain_lookup_exceptions_do_not_prevent_netconfig(
             self,
             mock_keystone):
         """ensure that all exceptions are catched and do not break the
@@ -536,34 +474,7 @@ class TestDhcpRpcCustomNetworkConfigurator(base.BaseTestCase):
         self.assertIsNone(upstreams)
 
     @mock.patch.object(CustomNetworkConfigurator, "_keystone_connection")
-    def test_domain_lookup_exceptions_do_not_prevent_netconfig(
-            self,
-            mock_keystone):
-        """ensure that all exceptions are catched and do not break the
-           rpc call
-        """
-        # TODO(mutax): remove this test after migration to new config file
-
-        # we manipulate the network, so we need fresh mock objects
-        mock_network = {'id': 123, 'project_id': 666}
-        mock_project = MockedDBObj(id=666, domain_id=42)
-
-        mock_keystone.get_project.return_value = mock_project
-        mock_keystone.get_domain.side_effect = Exception('Test')
-
-        cfg.CONF.set_override('enabled', True,
-                              group='customdns')
-        cfg.CONF.set_override('domain_name_prefixes', ['mydomain'],
-                              group='customdns')
-
-        cnc = CustomNetworkConfigurator()
-
-        cnc.add_dnssettings_to_net(mock_network)
-        upstreams = mock_network.get('dns_custom_upstreams')
-        self.assertIsNone(upstreams)
-
-    @mock.patch.object(CustomNetworkConfigurator, "_keystone_connection")
-    def test_network_ednslogging_setting_yaml(self, mock_keystone):
+    def test_network_ednslogging_setting(self, mock_keystone):
         """ensure the networks can be configured with or without edns logging
         """
 
@@ -594,8 +505,8 @@ class TestDhcpRpcCustomNetworkConfigurator(base.BaseTestCase):
         self.assertIsNone(mock_network_nologging.get('dns_custom_upstreams'))
         self.assertIsNone(mock_network_logging.get('dns_custom_upstreams'))
 
-    def test_exceptions_configerror_types_yaml(self):
-        """ensure we are catching non-ip entries
+    def test_exceptions_configerror_types(self):
+        """ensure we are catching non-ip entries in the dns server settings
         """
 
         example_config = b"""


### PR DESCRIPTION
The customdns configuration is now done using a yaml config file pointed to in the neutron config file.

This commit removes the now unused options from the configuration, removes the obsolete code and the tests and cleans up the code.

With this change the yaml configuration file is now mandatory when the customdns feature is enabled.

We also renamed some of the tests to better describe their purpose and renamed the "doubled" tests for the functionality back to the original names by removing the _yaml postfix.

Additional tests ensure the configuration file is required when the customdns feature is enabled and exceptions are handled accordingly.