### PR TITLE
[dnsmasq] allow setting of ntp servers based on OpenStack Domain

### DIFF
--- a/neutron/agent/linux/dhcp.py
+++ b/neutron/agent/linux/dhcp.py
@@ -569,6 +569,40 @@ class Dnsmasq(DhcpLocalProcess):
         cmd.append('--conf-file=%s' %
                    (self.conf.dnsmasq_config_file.strip() or '/dev/null'))
 
+        # check if the network has custom NTP servers set
+        if hasattr(self.network, 'ntp_servers'):
+            # Do some input validation on the data we got via rpc call, to
+            # avoid dnsmasq not starting. Should not
+            # happen as we are doing validation on the server side as well.
+            ntp_servers = self.network.ntp_servers
+        else:
+            # fallback to the configuration defaults (if set)
+            ntp_servers = self.conf.dnsmasq_ntp_servers
+
+        if ntp_servers:
+            # only if we have ntp servers, append the option.
+            # note that if the option is present in the config file, the config
+            # file wile take precedence!
+            servers = []
+            for server in ntp_servers:
+                try:
+                    address = ipaddress.ip_address(server)
+                    if address.version == 4:
+                        servers.append(address.compressed)
+                    else:
+                        LOG.error('Invalid NTP server "%s" for network %s'
+                                  ' DHCP option 42 only supports IPv4',
+                                  server, self.network.id)
+                except ValueError:
+                    LOG.error('Invalid NTP server "%s" for network %s',
+                              server, self.network.id)
+
+            servers = ",".join(servers)
+            LOG.debug("Adding NTP servers %s for network %s",
+                      servers,
+                      self.network.id)
+            cmd.append(f'--dhcp-option=42,{servers}')
+
         # if the network has custom upstreams set, we will use them instead
         if hasattr(self.network, 'dns_custom_upstreams'):
             # Do some input validation on the data we got via rpc call, to

--- a/neutron/api/rpc/handlers/dhcp_rpc.py
+++ b/neutron/api/rpc/handlers/dhcp_rpc.py
@@ -73,32 +73,47 @@ class CustomNetworkConfigError(Exception):
 class CustomNetworkSettings:
     dns_ednslogging_enabled: bool
     dns_custom_upstreams: set[str] | None = None
+    ntp_servers: set[str] | None = None
 
     def __post_init__(self):
         if not isinstance(self.dns_ednslogging_enabled, bool):
             raise TypeError(_("dns_ednslogging_enabled must be a bool: %s")
                             % self.dns_ednslogging_enabled)
-        if self.dns_custom_upstreams:
-            self._validate_upstreams()
 
-    def _validate_upstreams(self):
+        if self.dns_custom_upstreams:
+            try:
+                self.dns_custom_upstreams = self._validate_as_ip_adresslist(
+                        self.dns_custom_upstreams)
+            except ValueError as e:
+                LOG.error("Invalid DNS server list: %s", e)
+                raise
+
+        if self.ntp_servers:
+            try:
+                self.ntp_servers = self._validate_as_ip_adresslist(
+                        self.ntp_servers)
+            except ValueError as e:
+                LOG.error("Invalid NTP server list: %s", e)
+                raise
+
+    @staticmethod
+    def _validate_as_ip_adresslist(adresslist: set[str] | None) -> set[str]:
         """ensure that all elements are valid IP addresses and make it a
         set of strings containing the normalized IP addresses.
         """
-        if not self.dns_custom_upstreams:
-            self.dns_custom_upstreams = set()
-            return
+        if not adresslist:
+            return set()
 
         addrs: set[str] = set()
-        for item in self.dns_custom_upstreams:
+        for item in adresslist:
             try:
                 addr = ipaddress.ip_address(item)
                 addrs.add(addr.compressed)
             except ValueError:
-                LOG.error("not a valid IP for DNS entry: %s", item)
+                LOG.error("not a valid IP address: %s", item)
                 raise
 
-        self.dns_custom_upstreams = addrs
+        return addrs
 
 
 class CustomNetworkConfigurator:
@@ -150,7 +165,8 @@ class CustomNetworkConfigurator:
         valid_keys = mandatory_keys | {
                       'project_ids',
                       'domain_name_prefixes',
-                      'upstream_dns_servers'
+                      'upstream_dns_servers',
+                      'ntp_servers',
                     }
 
         for item in matches:
@@ -177,12 +193,14 @@ class CustomNetworkConfigurator:
             project_ids = item.get('project_ids', [])
             domain_prefixes = item.get('domain_name_prefixes', [])
             upstreams = item.get('upstream_dns_servers', [])
+            ntp_servers = item.get('ntp_servers', [])
             ednslogging = item['ednslogging']
 
             try:
                 netconfig = CustomNetworkSettings(
                     dns_ednslogging_enabled=ednslogging,
                     dns_custom_upstreams=set(upstreams),
+                    ntp_servers=set(ntp_servers),
                 )
             except (TypeError, ValueError) as e:
                 msg = _("Error parsing custom DNS config: %s") % e
@@ -231,21 +249,6 @@ class CustomNetworkConfigurator:
 
         # first check if we have a match in the project ids,
         # this is the cheapest lookup
-        if self._apply_project_settings(network_dict):
-            return
-
-        # next try to match openstack domain name prefixes.
-        self._apply_domain_settings(network_dict)
-
-    def _apply_project_settings(self, network_dict: dict) -> bool:
-        """apply project-specific DNS settings if they exist.
-        Returns True if settings were found to allow skipping of
-        further processing. Not to be called directly.
-        """
-
-        if not self._dns_config:
-            return False
-
         project_id = network_dict['project_id']
 
         # check if the project-id matches the list for custom settings
@@ -255,25 +258,33 @@ class CustomNetworkConfigurator:
                       "project %s matches: %s",
                       network_dict['id'], project_id, custom_config
                       )
+        else:
+            # next try to match openstack domain name prefixes.
+            custom_config = self._find_domain_settings(network_dict)
 
-            network_dict['dns_ednslogging_enabled'] = (
-                custom_config.dns_ednslogging_enabled)
+        if not custom_config:
+            return
 
-            if custom_config.dns_custom_upstreams:
-                network_dict['dns_custom_upstreams'] = (
-                    custom_config.dns_custom_upstreams)
-            return True
+        network_dict['dns_ednslogging_enabled'] = (
+            custom_config.dns_ednslogging_enabled)
 
-        return False
+        if custom_config.dns_custom_upstreams:
+            network_dict['dns_custom_upstreams'] = (
+                custom_config.dns_custom_upstreams)
 
-    def _apply_domain_settings(self, network_dict: dict) -> bool:
+        if custom_config.ntp_servers:
+            network_dict['ntp_servers'] = (
+                custom_config.ntp_servers)
+
+    def _find_domain_settings(self, network_dict: dict) -> (
+            CustomNetworkSettings | None):
         """apply domain-specific DNS settings if they exist.
         Returns True if settings were found to allow skipping of
         further processing for consistency. Not to be called directly.
         """
 
         if not self._dns_config:
-            return False
+            return None
 
         # try to retrieve the OpenStack domain name via the project id,
         # this uses a local cache and on a cache miss queries keystone
@@ -301,7 +312,7 @@ class CustomNetworkConfigurator:
             LOG.warning('Unable to retrieve domain name for project %s,'
                         ' falling back to default settings for network %s',
                         project_id, network_dict['id'])
-            return False
+            return None
 
         # check if the OpenStack domain name starts with one of the prefixes
         # from our config (or is equal).
@@ -322,14 +333,8 @@ class CustomNetworkConfigurator:
                           domain_prefix, custom_config
                           )
 
-                network_dict['dns_ednslogging_enabled'] = (
-                    custom_config.dns_ednslogging_enabled)
-
-                if custom_config.dns_custom_upstreams:
-                    network_dict['dns_custom_upstreams'] = (
-                        custom_config.dns_custom_upstreams)
-                return True
-        return False
+                return custom_config
+        return None
 
     def _add_legacy_dnssettings_to_net(self, network_dict):
         """If the network domain or project match the configured list,

--- a/neutron/conf/agent/dhcp.py
+++ b/neutron/conf/agent/dhcp.py
@@ -109,6 +109,10 @@ DNSMASQ_OPTS = [
                 default=[],
                 help=_('Comma-separated list of the DNS servers which will be '
                        'used as forwarders.')),
+    cfg.ListOpt('dnsmasq_ntp_servers',
+                default=[],
+                help=_('Comma-separated list of NTP server IPs which will be '
+                       'distributed via DHCP option 42.')),
     cfg.StrOpt('dnsmasq_base_log_dir',
                help=_("Base log dir for dnsmasq logging. "
                       "The log contains DHCP and DNS log information and "

--- a/neutron/tests/unit/agent/linux/test_dhcp.py
+++ b/neutron/tests/unit/agent/linux/test_dhcp.py
@@ -1754,6 +1754,74 @@ class TestDnsmasq(TestBase):
                           ],
                          network=network)
 
+    def test_spawn_cfg_ntp_servers_not_configured(self):
+        """ensure we still start up when no ntp servers are set in our
+        configuration and that no dhcp option is added.
+        """
+
+        network = FakeDualNetwork()
+
+        self._test_spawn(['--conf-file=',
+                          '--domain=openstacklocal',
+                          ],
+                         network=network)
+
+    def test_spawn_cfg_ntp_servers_default_from_config(self):
+        self.conf.set_override('dnsmasq_ntp_servers',
+                               ['192.0.2.3', '192.0.2.4'])
+        network = FakeDualNetwork()
+
+        self._test_spawn(['--conf-file=',
+                          '--dhcp-option=42,192.0.2.3,192.0.2.4',
+                          '--domain=openstacklocal',
+                          ],
+                         network=network)
+
+    def test_spawn_cfg_ntp_servers_override_config(self):
+        self.conf.set_override('dnsmasq_ntp_servers',
+                               ['192.0.2.3', '192.0.2.4'])
+        network = FakeDualNetwork()
+        network.ntp_servers = ['192.0.2.1', '192.0.2.2']
+
+        self._test_spawn(['--conf-file=',
+                          '--dhcp-option=42,192.0.2.1,192.0.2.2',
+                          '--domain=openstacklocal',
+                          ],
+                         network=network)
+
+    def test_spawn_cfg_ntp_servers_ignore_ipv6_config(self):
+        """ensure we skip IPv6 addresses for dhcp option 42
+        from our default settings,
+        it only supports IPv4 addresses:
+        https://datatracker.ietf.org/doc/html/rfc2132#section-8.3
+        """
+        self.conf.set_override('dnsmasq_ntp_servers',
+                               ['192.0.2.3', '::1'])
+        network = FakeDualNetwork()
+
+        self._test_spawn(['--conf-file=',
+                          '--dhcp-option=42,192.0.2.3',
+                          '--domain=openstacklocal',
+                          ],
+                         network=network)
+
+    def test_spawn_cfg_ntp_servers_ignore_ipv6_rpc(self):
+        """ensure we skip IPv6 addresses for dhcp option 42
+        received via network config from the rpc server,
+        it only supports IPv4 addresses:
+        https://datatracker.ietf.org/doc/html/rfc2132#section-8.3
+        """
+        self.conf.set_override('dnsmasq_ntp_servers',
+                               ['192.0.2.3', '::1'])
+        network = FakeDualNetwork()
+        network.ntp_servers = ['192.0.2.1', '::1']
+
+        self._test_spawn(['--conf-file=',
+                          '--dhcp-option=42,192.0.2.1',
+                          '--domain=openstacklocal',
+                          ],
+                         network=network)
+
     @mock.patch.object(sanity_checks,
                        'dnsmasq_umbrella_supported', return_value=True)
     def test_spawn_cfg_enable_dnsmasq_log(self, _mock):

--- a/neutron/tests/unit/api/rpc/handlers/test_dhcp_rpc.py
+++ b/neutron/tests/unit/api/rpc/handlers/test_dhcp_rpc.py
@@ -131,6 +131,9 @@ class TestDhcpRpcCustomNetworkConfigurator(base.BaseTestCase):
                        upstream_dns_servers:
                         - 192.0.2.10
                         - 192.0.2.20
+                       ntp_servers:
+                        - 192.0.2.100
+                        - 192.0.2.101
                     -  domain_name_prefixes:
                         - ext-abcd
                         - ext-
@@ -138,6 +141,9 @@ class TestDhcpRpcCustomNetworkConfigurator(base.BaseTestCase):
                        upstream_dns_servers:
                         - 192.0.2.30
                         - 192.0.2.40
+                       ntp_servers:
+                        - 192.0.2.102
+                        - 192.0.2.103
                 """
 
         cnc = self._get_cnc_from_yaml_config(configdata=example_config)
@@ -145,9 +151,15 @@ class TestDhcpRpcCustomNetworkConfigurator(base.BaseTestCase):
         # CustomNetworkSettings will convert the list of IPs to a set
         # so we can compare them with ease below.
         config_1 = CustomNetworkSettings(
-                False, {'192.0.2.10', '192.0.2.20'})
+                dns_ednslogging_enabled=False,
+                dns_custom_upstreams={'192.0.2.10', '192.0.2.20'},
+                ntp_servers={'192.0.2.100', '192.0.2.101'},
+        )
         config_2 = CustomNetworkSettings(
-                True, {'192.0.2.30', '192.0.2.40'})
+                dns_ednslogging_enabled=True,
+                dns_custom_upstreams={'192.0.2.30', '192.0.2.40'},
+                ntp_servers={'192.0.2.102', '192.0.2.103'}
+        )
 
         example_config_expected = {
             'domains': {'ext-': config_2,
@@ -330,6 +342,44 @@ class TestDhcpRpcCustomNetworkConfigurator(base.BaseTestCase):
         self.assertIsNotNone(upstreams)
         self.assertIn(dns1, upstreams)
         self.assertIn(dns2, upstreams)
+        self.assertEqual(len(upstreams), 2)
+
+    @mock.patch.object(CustomNetworkConfigurator, "_keystone_connection")
+    def test_ntpserver_settings_yaml(self, mock_keystone):
+        """ensure the configured NTP server IPs are present in the network
+           dict returned
+        """
+
+        # we manipulate the network, so we need fresh mock objects
+        mock_network = {'id': 'net-123', 'project_id': 'p-666'}
+        mock_project = MockedDBObj(id='p-666', domain_id='d-42')
+        mock_domain = MockedDBObj(id='d-42', name='mydomain')
+
+        mock_keystone.get_project.return_value = mock_project
+        mock_keystone.get_domain.return_value = mock_domain
+
+        ntp1 = "2001:db8::456"
+        ntp2 = "192.0.2.123"
+
+        example_config = b"""
+                       matches:
+                           -  domain_name_prefixes:
+                               - mydomain
+                              ntp_servers:
+                               - %s
+                               - %s
+                              ednslogging: False
+                       """ % (ntp1.encode(), ntp2.encode())
+
+        cnc = self._get_cnc_from_yaml_config(configdata=example_config)
+
+        cnc.add_dnssettings_to_net(mock_network)
+        sentinel = object()
+        upstreams = mock_network.get('ntp_servers', sentinel)
+        self.assertNotEqual(sentinel, upstreams)
+        self.assertIsNotNone(upstreams)
+        self.assertIn(ntp1, upstreams)
+        self.assertIn(ntp2, upstreams)
         self.assertEqual(len(upstreams), 2)
 
     @mock.patch.object(CustomNetworkConfigurator, "_keystone_connection")


### PR DESCRIPTION
Similar to the recently introduced feature of setting custom DNS upstream servers for dnsmasq based on the OpenStack Domain or project of a network, this adds support for configuring the NTP servers distributed via DHCP option 42 to the clients.

Note: To take effect, the option must not be set in the dnsmasq config file, as commandline options are overwritten when they are only allowed to be given once.

Should be merged after https://github.com/sapcc/neutron/pull/110 (might require rebase)

Not tested in qa yet, and after merging of 110 some renaming should be considered, as we are not only configuring DNS any more. 

After that Draft status will be updated.