### PR TITLE
[dnsmasq] allow setting of ntp servers based on OpenStack Domain

### DIFF
--- a/neutron/agent/linux/dhcp.py
+++ b/neutron/agent/linux/dhcp.py
@@ -569,6 +569,39 @@ class Dnsmasq(DhcpLocalProcess):
         cmd.append('--conf-file=%s' %
                    (self.conf.dnsmasq_config_file.strip() or '/dev/null'))
 
+        # check if the network has custom NTP servers set,
+        # or fallback to the configuration defaults (if they are set)
+        ntp_servers = getattr(self.network, 'ntp_servers',
+                              self.conf.dnsmasq_ntp_servers)
+
+        if ntp_servers:
+            # only if we have ntp servers, append the option.
+            # note that if the option is present in the config file, the config
+            # file will take precedence!
+            servers = []
+            for server in ntp_servers:
+                try:
+                    address = ipaddress.ip_address(server)
+                    if address.version == 4:
+                        servers.append(address.compressed)
+                    else:
+                        LOG.error('Invalid NTP server "%s" for network %s'
+                                  ' DHCP option 42 only supports IPv4',
+                                  server, self.network.id)
+                except ValueError:
+                    LOG.error('Invalid NTP server "%s" for network %s',
+                              server, self.network.id)
+
+            if servers:
+                servers = ",".join(servers)
+                LOG.debug("Adding NTP servers %s for network %s",
+                          servers,
+                          self.network.id)
+                cmd.append(f'--dhcp-option=42,{servers}')
+            else:
+                LOG.warning('No valid NTP servers in config for network %s',
+                            self.network.id)
+
         # if the network has custom upstreams set, we will use them instead
         if hasattr(self.network, 'dns_custom_upstreams'):
             # Do some input validation on the data we got via rpc call, to

--- a/neutron/api/rpc/handlers/dhcp_rpc.py
+++ b/neutron/api/rpc/handlers/dhcp_rpc.py
@@ -73,6 +73,7 @@ class CustomNetworkConfigError(Exception):
 class CustomNetworkSettings:
     dns_ednslogging_enabled: bool
     dns_custom_upstreams: set[str] | None = None
+    ntp_servers: set[str] | None = None
 
     def __post_init__(self):
 
@@ -80,22 +81,28 @@ class CustomNetworkSettings:
             raise TypeError(_("dns_ednslogging_enabled must be a bool: %s")
                             % self.dns_ednslogging_enabled)
 
-        if self.dns_custom_upstreams:
-            try:
-                self.dns_custom_upstreams = self._validate_ip_addresses(
-                    self.dns_custom_upstreams)
-            except ValueError as e:
-                LOG.error("Invalid DNS server list: %s", e)
-                raise
+        try:
+            self.dns_custom_upstreams = self._validate_ip_addresses(
+                self.dns_custom_upstreams)
+        except ValueError as e:
+            LOG.error("Invalid DNS server list: %s", e)
+            raise
+
+        try:
+            self.ntp_servers = self._validate_ip_addresses(
+                    self.ntp_servers)
+        except ValueError as e:
+            LOG.error("Invalid NTP server list: %s", e)
+            raise
 
     @staticmethod
-    def _validate_ip_addresses(addresses: set[str] | None) -> set[str]:
+    def _validate_ip_addresses(addresses: set[str] | None) -> set[str] | None:
         """ensure that all elements are valid IP addresses and make it a
         set of strings containing the normalized IP addresses.
         """
 
         if not addresses:
-            return set()
+            return None
 
         validated: set[str] = set()
         for item in addresses:
@@ -115,18 +122,19 @@ class CustomNetworkConfigurator:
         self._KEYSTONE = None
         self._domain_id_cache = {}
         self._domain_name_cache = {}
-        self._dns_config: dict[str, dict[str, CustomNetworkSettings]] = {}
+        self._net_config: dict[str, dict[str, CustomNetworkSettings]] = {}
         self._config_file: str | None = cfg.CONF.customdns.config_file
         self._load_config()
 
     def _load_config(self):
-        """load or reload custom dns config from file."""
+        """load or reload custom network configurations from file."""
 
         if not self._config_file:
             raise CustomNetworkConfigError(_("no config_file set but custom "
                                              "network config requested"))
 
-        LOG.debug("loading customdns config from '%s'", self._config_file)
+        LOG.debug("loading custom network settings from '%s'",
+                  self._config_file)
 
         try:
             cfgfile = pathlib.Path(self._config_file)
@@ -140,25 +148,28 @@ class CustomNetworkConfigurator:
                    % self._config_file)
             raise CustomNetworkConfigError(msg)
 
-        # make an empty config file fail hard
+        # Fail when the file is completely empty, this is most likely
+        # a misconfiguration...
         try:
             matches = config['matches']
         except KeyError:
-            msg = (_("Missing 'matches:' in custom DNS config file '%s'") %
+            msg = (_("Missing 'matches:' in custom network settings "
+                     "configuration file '%s'") %
                    self._config_file)
             raise CustomNetworkConfigError(msg)
 
-        # but accept an intentionally empty list
+        # ... but accept an intentionally empty list
         if not matches:
             return
 
-        dns_config = {'projects': {}, 'domains': {}}
+        net_config = {'projects': {}, 'domains': {}}
 
         mandatory_keys = {'ednslogging', }
         valid_keys = mandatory_keys | {
                       'project_ids',
                       'domain_name_prefixes',
                       'upstream_dns_servers',
+                      'ntp_servers',
                     }
 
         for item in matches:
@@ -185,56 +196,57 @@ class CustomNetworkConfigurator:
             project_ids = item.get('project_ids', [])
             domain_prefixes = item.get('domain_name_prefixes', [])
             upstreams = item.get('upstream_dns_servers', [])
+            ntp_servers = item.get('ntp_servers', [])
             ednslogging = item['ednslogging']
 
             try:
                 netconfig = CustomNetworkSettings(
                     dns_ednslogging_enabled=ednslogging,
                     dns_custom_upstreams=set(upstreams),
+                    ntp_servers=set(ntp_servers),
                 )
             except (TypeError, ValueError) as e:
                 msg = _("Error parsing custom DNS config: %s") % e
                 raise CustomNetworkConfigError(msg)
 
             for project_id in project_ids:
-                if project_id in dns_config['projects']:
+                if project_id in net_config['projects']:
                     msg = _("project %s already configured!") % project_id
                     raise CustomNetworkConfigError(msg)
 
-                dns_config['projects'][project_id] = netconfig
+                net_config['projects'][project_id] = netconfig
 
             for domain_prefix in domain_prefixes:
-                if domain_prefix in dns_config['domains']:
+                if domain_prefix in net_config['domains']:
                     msg = (_("domain-prefix '%s' already configured!")
                            % domain_prefix)
                     raise CustomNetworkConfigError(msg)
 
-                dns_config['domains'][domain_prefix] = netconfig
+                net_config['domains'][domain_prefix] = netconfig
 
-        self._dns_config = dns_config
+        self._net_config = net_config
 
-    def add_dnssettings_to_net(self, network_dict):
-        """Add custom dns settings specified via external config file
+    def add_custom_settings_to_net(self, network_dict):
+        """Add the custom settings specified in the external config file
         to the network, if the network matches any of the criteria set in the
         config file.
         """
 
-        if not self._dns_config:
+        if not self._net_config:
             return
 
         # first check if we have a match in the project ids,
         # this is the cheapest lookup
-
         project_id = network_dict['project_id']
 
-        custom_config = self._dns_config['projects'].get(project_id)
+        custom_config = self._net_config['projects'].get(project_id)
         if custom_config:
             LOG.debug("setting custom settings for net %s, "
                       "project %s matches: %s",
                       network_dict['id'], project_id, custom_config
                       )
         else:
-            # try to match openstack domain name prefixes.
+            # now try to match openstack domain name prefixes.
             custom_config = self._find_domain_settings(network_dict)
 
         if not custom_config:
@@ -247,12 +259,16 @@ class CustomNetworkConfigurator:
             network_dict['dns_custom_upstreams'] = (
                 custom_config.dns_custom_upstreams)
 
+        if custom_config.ntp_servers:
+            network_dict['ntp_servers'] = (
+                custom_config.ntp_servers)
+
     def _find_domain_settings(self, network_dict: dict) -> (
             CustomNetworkSettings | None):
-        """lookup domain-specific DNS settings if they exist.
+        """lookup domain-specific Network settings (e.g., DNS) if they exist.
         """
 
-        if not self._dns_config:
+        if not self._net_config:
             return None
 
         # try to retrieve the OpenStack domain name via the project id,
@@ -270,8 +286,9 @@ class CustomNetworkConfigurator:
             # TODO(mutax): I do want to get the stack trace logged, but I
             #   also want to get a nice warning to the log independent of the
             #   source of the error - but now we log the same error twice.
-            LOG.exception('Failed to retrieve domain to set custom dns for'
-                          ' project %s of network %s - %s: %s',
+            LOG.exception('Failed to get OpenStack domain of project %s '
+                          'while checking for custom settings for network %s -'
+                          '%s: %s',
                           project_id, network_dict['id'], type(e), e
                           )
 
@@ -289,12 +306,12 @@ class CustomNetworkConfigurator:
         # i.e. abc- can provide settings for all domains starting with abc,
         # while at the same time abc-123 can be used to match a specific one
 
-        for domain_prefix in sorted(self._dns_config['domains'].keys(),
+        for domain_prefix in sorted(self._net_config['domains'].keys(),
                                     key=len,
                                     reverse=True):
 
             if domain_name.startswith(domain_prefix):
-                custom_config = self._dns_config['domains'][domain_prefix]
+                custom_config = self._net_config['domains'][domain_prefix]
 
                 LOG.debug("setting custom settings for net %s, "
                           "domain %s matches prefix %s: %s",
@@ -596,7 +613,7 @@ class DhcpRpcCallback(object):
                 'hosts': segment.hosts} for segment in network.segments]
 
         if self._config_lookup:
-            self._config_lookup.add_dnssettings_to_net(network_dict)
+            self._config_lookup.add_custom_settings_to_net(network_dict)
 
         return network_dict
 

--- a/neutron/conf/agent/dhcp.py
+++ b/neutron/conf/agent/dhcp.py
@@ -112,6 +112,10 @@ DNSMASQ_OPTS = [
                 default=[],
                 help=_('Comma-separated list of the DNS servers which will be '
                        'used as forwarders.')),
+    cfg.ListOpt('dnsmasq_ntp_servers',
+                default=[],
+                help=_('Comma-separated list of NTP server IPs which will be '
+                       'distributed via DHCP option 42.')),
     cfg.StrOpt('dnsmasq_base_log_dir',
                help=_("Base log dir for dnsmasq logging. "
                       "The log contains DHCP and DNS log information and "

--- a/neutron/tests/unit/agent/linux/test_dhcp.py
+++ b/neutron/tests/unit/agent/linux/test_dhcp.py
@@ -1754,6 +1754,74 @@ class TestDnsmasq(TestBase):
                           ],
                          network=network)
 
+    def test_spawn_cfg_ntp_servers_not_configured(self):
+        """ensure we still start up when no ntp servers are set in our
+        configuration and that no dhcp option is added.
+        """
+
+        network = FakeDualNetwork()
+
+        self._test_spawn(['--conf-file=',
+                          '--domain=openstacklocal',
+                          ],
+                         network=network)
+
+    def test_spawn_cfg_ntp_servers_default_from_config(self):
+        self.conf.set_override('dnsmasq_ntp_servers',
+                               ['192.0.2.3', '192.0.2.4'])
+        network = FakeDualNetwork()
+
+        self._test_spawn(['--conf-file=',
+                          '--dhcp-option=42,192.0.2.3,192.0.2.4',
+                          '--domain=openstacklocal',
+                          ],
+                         network=network)
+
+    def test_spawn_cfg_ntp_servers_override_config(self):
+        self.conf.set_override('dnsmasq_ntp_servers',
+                               ['192.0.2.3', '192.0.2.4'])
+        network = FakeDualNetwork()
+        network.ntp_servers = ['192.0.2.1', '192.0.2.2']
+
+        self._test_spawn(['--conf-file=',
+                          '--dhcp-option=42,192.0.2.1,192.0.2.2',
+                          '--domain=openstacklocal',
+                          ],
+                         network=network)
+
+    def test_spawn_cfg_ntp_servers_ignore_ipv6_config(self):
+        """ensure we skip IPv6 addresses for dhcp option 42
+        from our default settings,
+        it only supports IPv4 addresses:
+        https://datatracker.ietf.org/doc/html/rfc2132#section-8.3
+        """
+        self.conf.set_override('dnsmasq_ntp_servers',
+                               ['192.0.2.3', '::1'])
+        network = FakeDualNetwork()
+
+        self._test_spawn(['--conf-file=',
+                          '--dhcp-option=42,192.0.2.3',
+                          '--domain=openstacklocal',
+                          ],
+                         network=network)
+
+    def test_spawn_cfg_ntp_servers_ignore_ipv6_rpc(self):
+        """ensure we skip IPv6 addresses for dhcp option 42
+        received via network config from the rpc server,
+        it only supports IPv4 addresses:
+        https://datatracker.ietf.org/doc/html/rfc2132#section-8.3
+        """
+        self.conf.set_override('dnsmasq_ntp_servers',
+                               ['192.0.2.3', '::1'])
+        network = FakeDualNetwork()
+        network.ntp_servers = ['192.0.2.1', '::1']
+
+        self._test_spawn(['--conf-file=',
+                          '--dhcp-option=42,192.0.2.1',
+                          '--domain=openstacklocal',
+                          ],
+                         network=network)
+
     @mock.patch.object(sanity_checks,
                        'dnsmasq_umbrella_supported', return_value=True)
     def test_spawn_cfg_enable_dnsmasq_log(self, _mock):

--- a/neutron/tests/unit/api/rpc/handlers/test_dhcp_rpc.py
+++ b/neutron/tests/unit/api/rpc/handlers/test_dhcp_rpc.py
@@ -88,7 +88,7 @@ class TestDhcpRpcCustomNetworkConfigurator(base.BaseTestCase):
             mock_pathlib.assert_called_once()
 
             empty_dict = {}
-            cnc.add_dnssettings_to_net(empty_dict)
+            cnc.add_custom_settings_to_net(empty_dict)
             self.assertFalse(bool(empty_dict))
 
     def test_ensure_config_not_read_if_not_enabled(self):
@@ -149,7 +149,7 @@ class TestDhcpRpcCustomNetworkConfigurator(base.BaseTestCase):
             mock_pathlib.return_value = b"matches:\n"
             cnc = CustomNetworkConfigurator()
             mock_pathlib.assert_called_once()
-            self.assertEqual({}, cnc._dns_config)
+            self.assertEqual({}, cnc._net_config)
 
     def test_ensure_config_enabled_requires_valid_configfile(self):
         """Ensure that if the feature is enabled, we require a valid
@@ -206,7 +206,7 @@ class TestDhcpRpcCustomNetworkConfigurator(base.BaseTestCase):
                 mock_pathlib:
             mock_pathlib.return_value = no_config
             cnc = CustomNetworkConfigurator()
-            self.assertEqual({}, cnc._dns_config)
+            self.assertEqual({}, cnc._net_config)
 
     def test_yaml_config_loader(self):
         """Test if the yaml config is converted to the expected internal
@@ -225,6 +225,9 @@ class TestDhcpRpcCustomNetworkConfigurator(base.BaseTestCase):
                        upstream_dns_servers:
                         - 192.0.2.10
                         - 192.0.2.20
+                       ntp_servers:
+                        - 192.0.2.100
+                        - 192.0.2.101
                     -  domain_name_prefixes:
                         - ext-abcd
                         - ext-
@@ -232,6 +235,12 @@ class TestDhcpRpcCustomNetworkConfigurator(base.BaseTestCase):
                        upstream_dns_servers:
                         - 192.0.2.30
                         - 192.0.2.40
+                       ntp_servers:
+                        - 192.0.2.102
+                        - 192.0.2.103
+                    -  domain_name_prefixes:
+                        - no-opts
+                       ednslogging: True
                 """
 
         cnc = self._get_cnc_from_yaml_config(configdata=example_config)
@@ -239,22 +248,34 @@ class TestDhcpRpcCustomNetworkConfigurator(base.BaseTestCase):
         # CustomNetworkSettings will convert the list of IPs to a set
         # so we can compare them with ease below.
         config_1 = CustomNetworkSettings(
-                False, {'192.0.2.10', '192.0.2.20'})
+                dns_ednslogging_enabled=False,
+                dns_custom_upstreams={'192.0.2.10', '192.0.2.20'},
+                ntp_servers={'192.0.2.100', '192.0.2.101'},
+        )
         config_2 = CustomNetworkSettings(
-                True, {'192.0.2.30', '192.0.2.40'})
+                dns_ednslogging_enabled=True,
+                dns_custom_upstreams={'192.0.2.30', '192.0.2.40'},
+                ntp_servers={'192.0.2.102', '192.0.2.103'}
+        )
+        config_3 = CustomNetworkSettings(
+                dns_ednslogging_enabled=True,
+                dns_custom_upstreams=None,
+                ntp_servers=None
+        )
 
         example_config_expected = {
             'domains': {'ext-': config_2,
                         'ext-abc': config_1,
                         'ext-abcd': config_2,
-                        'ext-def': config_1
+                        'ext-def': config_1,
+                        'no-opts': config_3
                         },
             'projects': {'0631d17744fe4a04b16494ae9056ae17': config_1,
                          '5dc81c6355ff478188f8fda11a971c41': config_1
                          }
         }
 
-        self.assertEqual(example_config_expected, cnc._dns_config)
+        self.assertEqual(example_config_expected, cnc._net_config)
 
     @mock.patch.object(CustomNetworkConfigurator, "_keystone_connection")
     def test_no_match_no_change(self, mock_keystone):
@@ -284,7 +305,7 @@ class TestDhcpRpcCustomNetworkConfigurator(base.BaseTestCase):
 
         cnc = self._get_cnc_from_yaml_config(configdata=example_config)
 
-        cnc.add_dnssettings_to_net(mock_network)
+        cnc.add_custom_settings_to_net(mock_network)
 
         mock_keystone.get_project.assert_called_with('p-666')
         mock_keystone.get_domain.assert_called_with('d-42')
@@ -316,7 +337,7 @@ class TestDhcpRpcCustomNetworkConfigurator(base.BaseTestCase):
 
         cnc = self._get_cnc_from_yaml_config(configdata=example_config)
 
-        cnc.add_dnssettings_to_net(mock_network)
+        cnc.add_custom_settings_to_net(mock_network)
 
         mock_keystone.get_project.assert_called_with('p-666')
         mock_keystone.get_domain.assert_called_with('d-42')
@@ -355,7 +376,7 @@ class TestDhcpRpcCustomNetworkConfigurator(base.BaseTestCase):
 
         cnc = self._get_cnc_from_yaml_config(configdata=example_config)
 
-        cnc.add_dnssettings_to_net(mock_network)
+        cnc.add_custom_settings_to_net(mock_network)
         self.assertFalse(mock_network.get('dns_ednslogging_enabled'))
         sentinel = object()
         upstreams = mock_network.get('dns_custom_upstreams', sentinel)
@@ -363,6 +384,44 @@ class TestDhcpRpcCustomNetworkConfigurator(base.BaseTestCase):
         self.assertIsNotNone(upstreams)
         self.assertIn(dns1, upstreams)
         self.assertIn(dns2, upstreams)
+        self.assertEqual(len(upstreams), 2)
+
+    @mock.patch.object(CustomNetworkConfigurator, "_keystone_connection")
+    def test_ntpserver_settings(self, mock_keystone):
+        """ensure the configured NTP server IPs are present in the network
+           dict returned
+        """
+
+        # we manipulate the network, so we need fresh mock objects
+        mock_network = {'id': 'net-123', 'project_id': 'p-666'}
+        mock_project = MockedDBObj(id='p-666', domain_id='d-42')
+        mock_domain = MockedDBObj(id='d-42', name='mydomain')
+
+        mock_keystone.get_project.return_value = mock_project
+        mock_keystone.get_domain.return_value = mock_domain
+
+        ntp1 = "2001:db8::456"
+        ntp2 = "192.0.2.123"
+
+        example_config = b"""
+                       matches:
+                           -  domain_name_prefixes:
+                               - mydomain
+                              ntp_servers:
+                               - %s
+                               - %s
+                              ednslogging: False
+                       """ % (ntp1.encode(), ntp2.encode())
+
+        cnc = self._get_cnc_from_yaml_config(configdata=example_config)
+
+        cnc.add_custom_settings_to_net(mock_network)
+        sentinel = object()
+        upstreams = mock_network.get('ntp_servers', sentinel)
+        self.assertNotEqual(sentinel, upstreams)
+        self.assertIsNotNone(upstreams)
+        self.assertIn(ntp1, upstreams)
+        self.assertIn(ntp2, upstreams)
         self.assertEqual(len(upstreams), 2)
 
     @mock.patch.object(CustomNetworkConfigurator, "_keystone_connection")
@@ -403,7 +462,7 @@ class TestDhcpRpcCustomNetworkConfigurator(base.BaseTestCase):
 
         cnc = self._get_cnc_from_yaml_config(configdata=example_config)
 
-        cnc.add_dnssettings_to_net(mock_network)
+        cnc.add_custom_settings_to_net(mock_network)
 
         self.assertFalse(mock_network.get('dns_ednslogging_enabled'))
 
@@ -438,7 +497,7 @@ class TestDhcpRpcCustomNetworkConfigurator(base.BaseTestCase):
 
         cnc = self._get_cnc_from_yaml_config(configdata=example_config)
 
-        cnc.add_dnssettings_to_net(mock_network)
+        cnc.add_custom_settings_to_net(mock_network)
         upstreams = mock_network.get('dns_custom_upstreams')
         self.assertIsNone(upstreams)
 
@@ -469,7 +528,7 @@ class TestDhcpRpcCustomNetworkConfigurator(base.BaseTestCase):
 
         cnc = self._get_cnc_from_yaml_config(configdata=example_config)
 
-        cnc.add_dnssettings_to_net(mock_network)
+        cnc.add_custom_settings_to_net(mock_network)
         upstreams = mock_network.get('dns_custom_upstreams')
         self.assertIsNone(upstreams)
 
@@ -494,8 +553,8 @@ class TestDhcpRpcCustomNetworkConfigurator(base.BaseTestCase):
 
         cnc = self._get_cnc_from_yaml_config(configdata=example_config)
 
-        cnc.add_dnssettings_to_net(mock_network_nologging)
-        cnc.add_dnssettings_to_net(mock_network_logging)
+        cnc.add_custom_settings_to_net(mock_network_nologging)
+        cnc.add_custom_settings_to_net(mock_network_logging)
 
         # assert we get the correct settings when no nameservers are set
         # but logging is configured accordingly


### PR DESCRIPTION
Similar to the recently introduced feature of setting custom DNS upstream servers for dnsmasq based on the OpenStack Domain or project of a network, this adds support for configuring the NTP servers distributed via DHCP option 42 to the clients.

Note: To take effect, the option must not be set in the dnsmasq config file, as commandline options are overwritten when they are only allowed to be given once.