### PR TITLE
Regularly run the agent check

### DIFF
--- a/neutron/agent/dhcp/agent.py
+++ b/neutron/agent/dhcp/agent.py
@@ -88,21 +88,16 @@ def _remove_status_file():
     LOG.info("Agent status file %s removed", AGENT_STATUS_FILE)
 
 
-def _find_missing_netns(active_networks):
+def _find_missing_netns(active_network_ids):
     ns = Path(netns.NETNS_RUN_DIR)
-    active_ns = set()
+    active_nets = set(active_network_ids)
     synced_nets = set()
-
-    for net in active_networks:
-        # admin_state_up is a boolean
-        if any(s for s in net.subnets if s.enable_dhcp) and net.admin_state_up:
-            active_ns.add(net.namespace)
 
     for net in ns.iterdir():
         if net.name.startswith('qdhcp-'):
-            synced_nets.add(net.name)
+            synced_nets.add(net.name.removeprefix('qdhcp-'))
 
-    return active_ns - synced_nets
+    return active_nets - synced_nets
 
 
 def _create_status_file(ready, message):
@@ -130,13 +125,13 @@ def _write_status_failure(error):
     _create_status_file(False, str(error))
 
 
-def _write_sync_status(active_networks):
-    missing_netns = _find_missing_netns(active_networks)
+def _write_sync_status(active_network_ids):
+    missing_netns = _find_missing_netns(active_network_ids)
 
     if missing_netns:
         ready = False
-        message = (f"Missing {len(missing_netns)} of {len(active_networks)} "
-                   f"networks - {', '.join(sorted(missing_netns)[:5])}")
+        message = (f"Missing {len(missing_netns)} of {len(active_network_ids)}"
+                   f" networks - {', '.join(sorted(missing_netns)[:5])}")
     else:
         ready = True
         message = "All networks synced"
@@ -413,7 +408,7 @@ class DhcpAgent(manager.Manager):
             # was down
             self.dhcp_ready_ports |= set(self.cache.get_port_ids(only_nets))
             LOG.info('Synchronizing state complete')
-            _write_sync_status(active_networks)
+            _write_sync_status(self.cache.get_network_ids())
         except Exception as e:
             if only_nets:
                 for network_id in only_nets:
@@ -461,6 +456,7 @@ class DhcpAgent(manager.Manager):
     @utils.exception_logger()
     def _periodic_resync_helper(self):
         """Resync the dhcp state at the configured interval and throttle."""
+        last_check = time.monotonic()
         while True:
             # threading.Event.wait blocks until the internal flag is true. It
             # returns the internal flag on exit, so it will always return True
@@ -485,6 +481,12 @@ class DhcpAgent(manager.Manager):
                     LOG.debug("resync (%(network)s): %(reason)s",
                               {"reason": r, "network": net})
                 self.sync_state(list(reasons.keys()))
+                # sync state also performs a _write_sync_status
+                last_check = time.monotonic()
+            elif (last_check + cfg.CONF.dhcp_agent_check_interval <
+                  time.monotonic()):
+                last_check = time.monotonic()
+                _write_sync_status(self.cache.get_network_ids())
 
     def periodic_resync(self):
         """Spawn a thread to periodically resync the dhcp state."""

--- a/neutron/conf/agent/dhcp.py
+++ b/neutron/conf/agent/dhcp.py
@@ -92,6 +92,9 @@ DHCP_AGENT_OPTS = [
                help=_("resolv.conf search domains inside network namespaces. "
                       "If not set uses the dns_domain. Set to empty string "
                       "to disable search parameter")),
+    cfg.IntOpt('dhcp_agent_check_interval', default=30,
+               help=_('Number of seconds between running '
+                      'the dhcp-agent-check for detecting missing networks')),
 ]
 
 DHCP_OPTS = [

--- a/neutron/tests/unit/agent/dhcp/test_agent.py
+++ b/neutron/tests/unit/agent/dhcp/test_agent.py
@@ -2885,14 +2885,8 @@ class TestAgentStatus(base.BaseTestCase):
 
     def test_find_missing_netns_with_missing_and_present(self):
         with TemporaryDirectory() as tmpdir:
-            active_net_ids = ["present-network-id",
-                              "present-in-neutron-db-but-not-on-agent"]
-            active_networks = set(
-                mock.Mock(id=netid, namespace=f"qdhcp-{netid}",
-                          admin_state_up=True,
-                          subnets=[mock.Mock(enable_dhcp=True)])
-                for netid in active_net_ids
-            )
+            active_networks = {"present-network-id",
+                              "present-in-neutron-db-but-not-on-agent"}
 
             # Create a netns file for the present network only
             netns_dir = Path(tmpdir)
@@ -2907,25 +2901,19 @@ class TestAgentStatus(base.BaseTestCase):
 
             self.assertEqual(1, len(missing_netns))
             self.assertEqual(
-                "qdhcp-present-in-neutron-db-but-not-on-agent",
+                "present-in-neutron-db-but-not-on-agent",
                 missing_netns.pop(),
             )
 
             # Test successfully synced network (all namespaces present)
-            active_net_ids = ["synced-network-id"]
-            all_synced_networks = set(
-                mock.Mock(id=netid, namespace=f"qdhcp-{netid}",
-                          admin_state_up=True,
-                          subnets=[mock.Mock(enable_dhcp=True)])
-                for netid in active_net_ids
-            )
+            active_net_ids = {"synced-network-id"}
 
             synced_netns_file = netns_dir / 'qdhcp-synced-network-id'
             synced_netns_file.touch()
 
             with mock.patch.object(netns, 'NETNS_RUN_DIR', tmpdir):
                 missing_netns = dhcp_agent._find_missing_netns(
-                    all_synced_networks)
+                    active_net_ids)
 
             self.assertEqual(0, len(missing_netns))
             self.assertEqual(set(), missing_netns)
@@ -2958,13 +2946,7 @@ class TestAgentStatus(base.BaseTestCase):
             netns_dir = Path(tmpdir)
 
             # Create networks with corresponding namespace files (all synced)
-            active_net_ids = ["network-1", "network-2"]
-            active_networks = set(
-                mock.Mock(id=netid, namespace=f"qdhcp-{netid}",
-                          admin_state_up=True,
-                          subnets=[mock.Mock(enable_dhcp=True)])
-                for netid in active_net_ids
-            )
+            active_net_ids = {"network-1", "network-2"}
 
             # Create netns files for all networks
             (netns_dir / 'qdhcp-network-1').touch()
@@ -2973,7 +2955,7 @@ class TestAgentStatus(base.BaseTestCase):
             with mock.patch.object(dhcp_agent, 'AGENT_STATUS_FILE',
                                    status_file_path):
                 with mock.patch.object(netns, 'NETNS_RUN_DIR', tmpdir):
-                    dhcp_agent._write_sync_status(active_networks)
+                    dhcp_agent._write_sync_status(active_net_ids)
 
                 # Verify the file was created
                 self.assertTrue(status_file_path.exists())
@@ -2993,17 +2975,11 @@ class TestAgentStatus(base.BaseTestCase):
             netns_dir = Path(tmpdir)
 
             # Create networks but only create netns file for one
-            active_net_ids = [
+            active_net_ids = {
                 "synced-network",
                 "missing-network-1",
                 "missing-network-2"
-            ]
-            active_networks = set(
-                mock.Mock(id=netid, namespace=f"qdhcp-{netid}",
-                          admin_state_up=True,
-                          subnets=[mock.Mock(enable_dhcp=True)])
-                for netid in active_net_ids
-            )
+            }
 
             # Create netns file only for the synced network
             (netns_dir / 'qdhcp-synced-network').touch()
@@ -3011,7 +2987,7 @@ class TestAgentStatus(base.BaseTestCase):
             with mock.patch.object(dhcp_agent, 'AGENT_STATUS_FILE',
                                    status_file_path):
                 with mock.patch.object(netns, 'NETNS_RUN_DIR', tmpdir):
-                    dhcp_agent._write_sync_status(active_networks)
+                    dhcp_agent._write_sync_status(active_net_ids)
 
             # Verify the file was created
             self.assertTrue(status_file_path.exists())
@@ -3023,8 +2999,8 @@ class TestAgentStatus(base.BaseTestCase):
             self.assertFalse(status["ready"])
             message = status["message"]
             self.assertIn("Missing 2 of 3 networks", message)
-            self.assertIn("qdhcp-missing-network-1", message)
-            self.assertIn("qdhcp-missing-network-2", message)
+            self.assertIn("missing-network-1", message)
+            self.assertIn("missing-network-2", message)
             self.assertIn("time", status)
             self.assertIsInstance(status["time"], (int, float))
 
@@ -3054,6 +3030,8 @@ class TestAgentStatusIntegration(base.BaseTestCase):
         active_networks = set(
             mock.Mock(id=netid, namespace=f"qdhcp-{netid}",
                       admin_state_up=True,
+                      non_local_subnets=[],
+                      ports=[],
                       subnets=[mock.Mock(enable_dhcp=True)])
             for netid in active_net_ids
         )
@@ -3075,12 +3053,10 @@ class TestAgentStatusIntegration(base.BaseTestCase):
                     dhcp = dhcp_agent.DhcpAgent(HOSTNAME)
                     attrs_to_mock = dict(
                         (a, mock.DEFAULT)
-                        for a in ['disable_dhcp_helper', 'cache',
-                                  'safe_configure_dhcp_for_network']
+                        for a in ['disable_dhcp_helper', 'call_driver',
+                                  'update_isolated_metadata_proxy']
                     )
-                    with mock.patch.multiple(dhcp, **attrs_to_mock) as mocks:
-                        mocks['cache'].get_network_ids.return_value = []
-                        mocks['cache'].get_port_ids.return_value = range(4)
+                    with mock.patch.multiple(dhcp, **attrs_to_mock):
                         with mock.patch.object(netns, 'NETNS_RUN_DIR', net_ns):
                             dhcp.sync_state()
 


### PR DESCRIPTION
Problem:
The sync_loop runs only when triggered by specific events (e.g., network create/delete operations). This means the agent status check does not run regularly as previously assumed.

In rapid create/delete scenarios, the status can become unsynced: the network exists in the database but the network namespace is never created. From Neutron's perspective everything appears fine, but the agent status shows unsynced and never updates.

Solution:
Use the cache as the source of truth for agent readiness checks. The cache is kept up-to-date by the agent on every operation (create/ delete network/port/subnet). Run regular checks against the cache to determine if all networks are synced and mark the agent ready accordingly.

For detecting when the cache is out of sync, we rely on other measures such as the custom exporter for network namespaces and MariaDB exports.