### PR TITLE
Backport ossn 0102 parent permission patches

### DIFF
--- a/neutron/services/conntrack_helper/plugin.py
+++ b/neutron/services/conntrack_helper/plugin.py
@@ -108,9 +108,9 @@ class Plugin(l3_conntrack_helper.ConntrackHelperPluginBase):
         if objs:
             return (objs[0], param)
 
-    def _get_conntrack_helper(self, context, id):
+    def _get_conntrack_helper(self, context, id, router_id):
         cth_obj = cth.ConntrackHelper.get_object(context, id=id)
-        if not cth_obj:
+        if not cth_obj or cth_obj.router_id != router_id:
             raise cth_exc.ConntrackHelperNotFound(id=id)
         return cth_obj
 
@@ -153,7 +153,7 @@ class Plugin(l3_conntrack_helper.ConntrackHelperPluginBase):
         conntrack_helper = conntrack_helper.get(apidef.RESOURCE_NAME)
         try:
             with db_api.CONTEXT_WRITER.using(context):
-                cth_obj = self._get_conntrack_helper(context, id)
+                cth_obj = self._get_conntrack_helper(context, id, router_id)
                 cth_obj.update_fields(conntrack_helper, reset_changes=True)
                 self._check_conntrack_helper_constraints(cth_obj)
                 cth_obj.update()
@@ -171,7 +171,7 @@ class Plugin(l3_conntrack_helper.ConntrackHelperPluginBase):
     @db_base_plugin_common.make_result_with_fields
     @db_base_plugin_common.convert_result_to_dict
     def get_router_conntrack_helper(self, context, id, router_id, fields=None):
-        return self._get_conntrack_helper(context, id)
+        return self._get_conntrack_helper(context, id, router_id)
 
     @db_base_plugin_common.make_result_with_fields
     @db_base_plugin_common.convert_result_to_dict
@@ -185,7 +185,7 @@ class Plugin(l3_conntrack_helper.ConntrackHelperPluginBase):
                                                router_id=router_id, **filters)
 
     def delete_router_conntrack_helper(self, context, id, router_id):
-        cth_obj = self._get_conntrack_helper(context, id)
+        cth_obj = self._get_conntrack_helper(context, id, router_id)
         with db_api.CONTEXT_WRITER.using(context):
             cth_obj.delete()
         self.push_api.push(context, [cth_obj], rpc_events.DELETED)

--- a/neutron/services/portforwarding/pf_plugin.py
+++ b/neutron/services/portforwarding/pf_plugin.py
@@ -416,7 +416,7 @@ class PortForwardingPlugin(fip_pf.PortForwardingPluginBase):
             with db_api.CONTEXT_WRITER.using(context):
                 fip_obj = self._get_fip_obj(context, floatingip_id)
                 pf_obj = pf.PortForwarding.get_object(context, id=id)
-                if not pf_obj:
+                if not pf_obj or pf_obj.floatingip_id != floatingip_id:
                     raise pf_exc.PortForwardingNotFound(id=id)
                 original_pf_obj = copy.deepcopy(pf_obj)
                 ori_internal_port_id = pf_obj.internal_port_id
@@ -669,7 +669,7 @@ class PortForwardingPlugin(fip_pf.PortForwardingPluginBase):
                                        fields=None):
         self._get_fip_obj(context, floatingip_id)
         obj = pf.PortForwarding.get_object(context, id=id)
-        if not obj:
+        if not obj or obj.floatingip_id != floatingip_id:
             raise pf_exc.PortForwardingNotFound(id=id)
         return obj
 

--- a/neutron/tests/functional/services/conntrack_helper/test_conntrack_helper.py
+++ b/neutron/tests/functional/services/conntrack_helper/test_conntrack_helper.py
@@ -125,3 +125,30 @@ class ConntrackHelperTestCase(ml2_test_base.ML2TestFramework,
         self.assertRaises(cth_exc.ConntrackHelperNotFound,
                           self.cth_plugin.delete_router_conntrack_helper,
                           self.context, INVALID_ID, self.router['id'])
+
+    def test_negative_singleton_operations_wrong_router(self):
+        res = self.cth_plugin.create_router_conntrack_helper(
+            self.context, self.router['id'], self.conntack_helper)
+        other_router = self._create_router(distributed=True)
+        new_conntack_helper = {
+            apidef.RESOURCE_NAME:
+                {apidef.PROTOCOL: 'udp',
+                 apidef.PORT: 6969,
+                 apidef.HELPER: 'tftp'}
+        }
+        self.assertRaises(
+            cth_exc.ConntrackHelperNotFound,
+            self.cth_plugin.get_router_conntrack_helper,
+            self.context, res['id'], other_router['id'])
+        self.assertRaises(
+            cth_exc.ConntrackHelperNotFound,
+            self.cth_plugin.update_router_conntrack_helper,
+            self.context, res['id'], other_router['id'],
+            new_conntack_helper)
+        self.assertRaises(
+            cth_exc.ConntrackHelperNotFound,
+            self.cth_plugin.delete_router_conntrack_helper,
+            self.context, res['id'], other_router['id'])
+        helper = self.cth_plugin.get_router_conntrack_helper(
+            self.context, res['id'], self.router['id'])
+        self.assertEqual(res['id'], helper['id'])

--- a/neutron/tests/unit/services/conntrack_helper/test_plugin.py
+++ b/neutron/tests/unit/services/conntrack_helper/test_plugin.py
@@ -193,9 +193,10 @@ class TestConntrackHelperPlugin(testlib_api.SqlTestCase):
         cth_obj = mock.Mock()
         cth_obj.helper = 'tftp'
         cth_obj.protocol = 'udp'
+        cth_obj.router_id = 'fake-router'
         mock_cth_get_object.return_value = cth_obj
         self.cth_plugin.update_router_conntrack_helper(
-            self.ctxt, 'cth_id', mock.ANY, **cth_input)
+            self.ctxt, 'cth_id', 'fake-router', **cth_input)
         mock_cth_get_object.assert_called_once_with(self.ctxt, id='cth_id')
         self.assertTrue(cth_obj.update_fields)
         self.assertTrue(cth_obj.update)
@@ -216,12 +217,31 @@ class TestConntrackHelperPlugin(testlib_api.SqlTestCase):
         self.assertRaises(
             cth_exc.ConntrackHelperNotFound,
             self.cth_plugin.update_router_conntrack_helper,
-            self.ctxt, 'cth_id', mock.ANY, **cth_input)
+            self.ctxt, 'cth_id', 'fake-router', **cth_input)
+
+    @mock.patch.object(conntrack_helper.ConntrackHelper, 'get_object')
+    def test_negative_update_conntrack_helper_wrong_router(
+            self, mock_cth_get_object):
+        cth_input = {
+            'conntrack_helper': {
+                'conntrack_helper': {
+                    'protocol': 'udp',
+                    'port': 69,
+                    'helper': 'tftp'}
+            }
+        }
+        mock_cth_get_object.return_value = mock.Mock(
+            router_id='correct-router')
+        self.assertRaises(
+            cth_exc.ConntrackHelperNotFound,
+            self.cth_plugin.update_router_conntrack_helper,
+            self.ctxt, 'cth_id', 'other-router', **cth_input)
 
     @mock.patch.object(conntrack_helper.ConntrackHelper, 'get_object')
     def test_get_conntrack_helper(self, get_object_mock):
+        get_object_mock.return_value = mock.Mock(router_id='fake-router')
         self.cth_plugin.get_router_conntrack_helper(
-            self.ctxt, 'cth_id', mock.ANY, fields=None)
+            self.ctxt, 'cth_id', 'fake-router', fields=None)
         get_object_mock.assert_called_once_with(self.ctxt, id='cth_id')
 
     @mock.patch.object(conntrack_helper.ConntrackHelper, 'get_object')
@@ -230,7 +250,16 @@ class TestConntrackHelperPlugin(testlib_api.SqlTestCase):
         self.assertRaises(
             cth_exc.ConntrackHelperNotFound,
             self.cth_plugin.get_router_conntrack_helper,
-            self.ctxt, 'cth_id', mock.ANY, fields=None)
+            self.ctxt, 'cth_id', 'fake-router', fields=None)
+
+    @mock.patch.object(conntrack_helper.ConntrackHelper, 'get_object')
+    def test_negative_get_conntrack_helper_wrong_router(self,
+                                                        get_object_mock):
+        get_object_mock.return_value = mock.Mock(router_id='victim-router')
+        self.assertRaises(
+            cth_exc.ConntrackHelperNotFound,
+            self.cth_plugin.get_router_conntrack_helper,
+            self.ctxt, 'cth_id', 'other-router', fields=None)
 
     @mock.patch.object(conntrack_helper.ConntrackHelper, 'get_objects')
     def test_get_conntrack_helpers(self, get_objects_mock):
@@ -248,7 +277,7 @@ class TestConntrackHelperPlugin(testlib_api.SqlTestCase):
                             helper='tftp')
         get_object_mock.return_value = cth_obj
         self.cth_plugin.delete_router_conntrack_helper(self.ctxt, 'cth_id',
-                                                       mock.ANY)
+                                                       'fake-router')
         cth_obj.delete.assert_called()
         mock_rpc_push.assert_called_once_with(
             self.ctxt, mock.ANY, rpc_events.DELETED)
@@ -258,4 +287,12 @@ class TestConntrackHelperPlugin(testlib_api.SqlTestCase):
         get_object_mock.return_value = None
         self.assertRaises(cth_exc.ConntrackHelperNotFound,
                           self.cth_plugin.delete_router_conntrack_helper,
-                          self.ctxt, 'cth_id', mock.ANY)
+                          self.ctxt, 'cth_id', 'fake-router')
+
+    @mock.patch.object(conntrack_helper.ConntrackHelper, 'get_object')
+    def test_negative_delete_conntrack_helper_wrong_router(
+            self, get_object_mock):
+        get_object_mock.return_value = mock.Mock(router_id='correct-router')
+        self.assertRaises(cth_exc.ConntrackHelperNotFound,
+                          self.cth_plugin.delete_router_conntrack_helper,
+                          self.ctxt, 'cth_id', 'other-router')

--- a/neutron/tests/unit/services/portforwarding/test_pf_plugin.py
+++ b/neutron/tests/unit/services/portforwarding/test_pf_plugin.py
@@ -90,9 +90,19 @@ class TestPortForwardingPlugin(testlib_api.SqlTestCase):
 
     @mock.patch.object(port_forwarding.PortForwarding, 'get_object')
     def test_get_floatingip_port_forwarding(self, get_object_mock):
+        get_object_mock.return_value = mock.Mock(floatingip_id='test-fip-id')
         self.pf_plugin.get_floatingip_port_forwarding(
             self.ctxt, 'pf_id', 'test-fip-id', fields=None)
         get_object_mock.assert_called_once_with(self.ctxt, id='pf_id')
+
+    @mock.patch.object(port_forwarding.PortForwarding, 'get_object')
+    def test_negative_get_floatingip_port_forwarding_wrong_parent(
+            self, get_object_mock):
+        get_object_mock.return_value = mock.Mock(floatingip_id='other-fip-id')
+        self.assertRaises(
+            pf_exc.PortForwardingNotFound,
+            self.pf_plugin.get_floatingip_port_forwarding,
+            self.ctxt, 'pf_id', 'test-fip-id', fields=None)
 
     @mock.patch.object(port_forwarding.PortForwarding, 'get_object',
                        return_value=None)
@@ -186,6 +196,7 @@ class TestPortForwardingPlugin(testlib_api.SqlTestCase):
         pf_obj.internal_ip_address = "10.0.0.1"
         pf_obj.internal_port = 22
         pf_obj.external_port = 222
+        pf_obj.floatingip_id = 'fip_id'
         mock_pf_get_object.return_value = pf_obj
         port_dict = {'id': 'ID', 'fixed_ips': [{"subnet_id": "test-subnet-id",
                                                 "ip_address": "10.0.0.1"}]}
@@ -287,6 +298,22 @@ class TestPortForwardingPlugin(testlib_api.SqlTestCase):
                     'floatingip_id': 'fip_id'}},
             'floatingip_id': 'fip_id'}
         mock_pf_get_object.return_value = None
+        self.assertRaises(
+            pf_exc.PortForwardingNotFound,
+            self.pf_plugin.update_floatingip_port_forwarding,
+            self.ctxt, 'pf_id', **pf_input)
+
+    @mock.patch.object(port_forwarding.PortForwarding, 'get_object')
+    def test_negative_update_floatingip_port_forwarding_wrong_parent(
+            self, mock_pf_get_object):
+        pf_input = {
+            'port_forwarding':
+                {'port_forwarding': {
+                    'internal_ip_address': '1.1.1.1',
+                    'floatingip_id': 'fip_id'}},
+            'floatingip_id': 'fip_id'}
+        mock_pf_get_object.return_value = mock.Mock(
+            floatingip_id='other-fip-id')
         self.assertRaises(
             pf_exc.PortForwardingNotFound,
             self.pf_plugin.update_floatingip_port_forwarding,

--- a/releasenotes/notes/fix-router-conntrack-helper-cross-project-access-ba1425c06abc45d5.yaml
+++ b/releasenotes/notes/fix-router-conntrack-helper-cross-project-access-ba1425c06abc45d5.yaml
@@ -1,0 +1,8 @@
+---
+security:
+  - |
+    Fixed an issue in the router conntrack helper API where a project
+    member authorized on one router could read, update, or delete another
+    project's conntrack helper by supplying an incorrect helper ID under their
+    own router ID in the request URL. Singleton operations now verify that
+    the conntrack helper belongs to the router specified in the URL.


### PR DESCRIPTION
We are not using the port forwarding or conntrack helper plugin - both APIs are a 404 in our infrastructure. We can backport the patches regardless, just to avoid an "are you affected" discussion.