### PR TITLE
Prevent cross-project subnet onboard on shared networks

### DIFF
--- a/neutron/db/db_base_plugin_v2.py
+++ b/neutron/db/db_base_plugin_v2.py
@@ -1453,6 +1453,17 @@ class NeutronDbPluginV2(db_base_plugin_common.DbBasePluginCommon,
         if not self._network_exists(context, network_id):
             raise exc.NetworkNotFound(net_id=network_id)
 
+        # Prevent cross-project subnet mutation: non-admin callers must own
+        # the network to onboard its subnets. Without this check a caller
+        # with visibility to a shared/RBAC network can reassign subnets
+        # owned by another project to their own subnetpool, potentially
+        # altering address-scope and L3 routing state for victim routers.
+        if not context.is_admin:
+            network = network_obj.Network.get_object(
+                context.elevated(), id=network_id)
+            if network.project_id != context.project_id:
+                raise exc.NotAuthorized()
+
         subnetpool = subnetpool_obj.SubnetPool.get_object(context,
                                                           id=subnetpool_id)
         if not subnetpool:

--- a/neutron/tests/unit/extensions/test_subnet_onboard.py
+++ b/neutron/tests/unit/extensions/test_subnet_onboard.py
@@ -17,6 +17,7 @@
 import contextlib
 
 import netaddr
+from neutron_lib import context as n_context
 from neutron_lib.db import api as db_api
 from neutron_lib import exceptions as exc
 from oslo_utils import uuidutils
@@ -189,6 +190,37 @@ class SubnetOnboardTestsBase(object):
             self.assertRaises(exc.NetworkNotFound,
                               self._test_onboard_subnet_non_existing_network,
                               subnetpool['id'], self.cidr_to_onboard)
+
+    def test_onboard_subnet_cross_project_not_authorized(self):
+        """Non-admin caller cannot onboard subnets from another project's net.
+        A project member must not be able to mutate subnets owned by a
+        different project via a shared network, even when the network is
+        RBAC-visible to the caller.
+        """
+        _project_id = 'project1-' + _uuid()
+        _ctx = n_context.Context('user1', _project_id, is_admin=False)
+
+        with self.subnetpool(self.ip_version,
+                             prefixes=self.subnetpool_prefixes,
+                             project_id=_project_id) as pool:
+            # Create a shared network owned by the default test project.
+            # Sharing is required so the user1 context can see (but not
+            # own) the network, reproducing the real-world condition.
+            with self.network(shared=True, as_admin=True) as shared_net:
+                network_id = shared_net['network']['id']
+                with self.subnet(network=shared_net,
+                                 cidr=self.cidr_to_onboard,
+                                 ip_version=self.ip_version):
+                    # The user1 can see the shared network but does
+                    # not own it: the call must be rejected.
+                    self.assertRaises(
+                        exc.NotAuthorized,
+                        self.driver.onboard_network_subnets,
+                        _ctx, pool['id'], {'network_id': network_id})
+
+                    # Admin call on the same pool/network must succeed.
+                    self._test_onboard_network_subnets(
+                        network_id, pool['id'])
 
     def _test_onboard_subnet_no_network_id(self, subnetpool_id,
                                            cidr_to_onboard):


### PR DESCRIPTION
Non-admin callers with visibility to a shared or RBAC network could onboard subnets owned by another project into their own subnetpool via ``onboard_network_subnets()``. This allowed the caller to alter the address-scope and L3 routing state of the network owner's routers.

Add a project ownership check that rejects non-admin requests when the caller's ``project_id`` does not match the network's ``project_id``.

Closes-Bug: #2152113
Assisted-By: Claude Opus 4.6

Change-Id: Ie484bff86f082c38a69d238e414d543200403402 (cherry picked from commit fdf0943dbecf577b4feabdbad331072116f15d43)

---
backport patch