### PR TITLE
Remove openstack-agent-checks from custom-requirements

### DIFF
--- a/custom-requirements.txt
+++ b/custom-requirements.txt
@@ -7,9 +7,6 @@ dumb-init
 # sentry client
 git+https://github.com/sapcc/sentrylogger.git@main#egg=sapcc_sentrylogger
 
-# agent checks for neutron
-openstack-agent-checks
-
 # uwsgi plugins
 uwsgi-dogstatsd
 uwsgi-shortmsecs


### PR DESCRIPTION
We no longer rely on openstack-agent-checks. Those checks were responsible for marking a network agent ready by asking the Neutron DB if all networks have been synced to the agent.

We replaced this with a local check by not depending on any third-party tool, where the agent writes its status to a file on which we base the probe.